### PR TITLE
Added option to show macro replacements

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -829,6 +829,7 @@ SC_VDECL int sc_debug;        /* debug/optimization options (bit field) */
 SC_VDECL int sc_packstr;      /* strings are packed by default? */
 SC_VDECL int sc_asmfile;      /* create .ASM file? */
 SC_VDECL int sc_listing;      /* create .LST file? */
+SC_VDECL int sc_macros;       /* show the macro replacements? */
 SC_VDECL int sc_compress;     /* compress bytecode? */
 SC_VDECL int sc_needsemicolon;/* semicolon required to terminate expressions? */
 SC_VDECL int sc_dataalign;    /* data alignment value */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -905,6 +905,7 @@ static void initglobals(void)
 
   sc_asmfile=FALSE;     /* do not create .ASM file */
   sc_listing=FALSE;     /* do not create .LST file */
+  sc_macros=FALSE;      /* show the macro replacements */
   skipinput=0;          /* number of lines to skip from the first input file */
   sc_ctrlchar=CTRL_CHAR;/* the escape character */
   litmax=sDEF_LITMAX;   /* current size of the literal table */
@@ -1111,6 +1112,11 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
         if (*(ptr+1)!='\0')
           about();
         sc_listing=TRUE;        /* skip second pass & code generation */
+        break;
+      case 'm':
+        if (*(ptr+1)!='\0')
+          about();
+        sc_macros=TRUE;        /* show the macro replacements */
         break;
       case 'o':
         if (oname)
@@ -1469,6 +1475,7 @@ static void about(void)
 #endif
     pc_printf("         -i<name> path for include files\n");
     pc_printf("         -l       create list file (preprocess only)\n");
+    pc_printf("         -m       shows the replacement of the macros\n");
     pc_printf("         -o<name> set base name of (P-code) output file\n");
     pc_printf("         -O<num>  optimization level (default=-O%d)\n",pc_optimize);
     pc_printf("             0    no optimization\n");

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1625,6 +1625,7 @@ static int substpattern(unsigned char *line,size_t buffersize,char *pattern,char
   int prefixlen;
   const unsigned char *p,*s,*e;
   unsigned char *args[10];
+  unsigned char *before;
   int match,arg,len,instring;
 
   memset(args,0,sizeof args);
@@ -1739,6 +1740,8 @@ static int substpattern(unsigned char *line,size_t buffersize,char *pattern,char
     if (strlen((char*)line) + len - (int)(s-line) > buffersize) {
       error(75);      /* line too long */
     } else {
+      before = malloc(strlen(line) + 1);
+      strcpy(before,line);
       /* substitute pattern */
       instring=0;
       strdel((char*)line,(int)(s-line));
@@ -1762,6 +1765,23 @@ static int substpattern(unsigned char *line,size_t buffersize,char *pattern,char
           s++;
         } /* if */
       } /* for */
+      if (sc_macros&&sc_status==statFIRST) {
+        int end = strlen(before) - 1, dummy;
+        if(before[end] == '\n')
+          before[end] = '\0';
+
+        end = strlen(line) - 1;
+        if (line[end] == '\n')
+        {
+          line[end] = '\0';
+          dummy = 1;
+        }
+        pc_printf("%s:%d MACRO(%s->%s) INPUT(%s) OUTPUT(%s)\n", inpfname, fline, pattern, substitution, before, line);
+        if (dummy == 1)
+          line[end] = '\n';
+
+        free(before);
+      }
     } /* if */
   } /* if */
 

--- a/source/compiler/scvars.c
+++ b/source/compiler/scvars.c
@@ -63,6 +63,7 @@ SC_VDEFINE int sc_debug=sCHKBOUNDS;         /* by default: bounds checking+asser
 SC_VDEFINE int sc_packstr= FALSE;           /* strings are packed by default? */
 SC_VDEFINE int sc_asmfile= FALSE;           /* create .ASM file? */
 SC_VDEFINE int sc_listing= FALSE;           /* create .LST file? */
+SC_VDEFINE int sc_macros= FALSE;            /* show the macro replacements? */
 SC_VDEFINE int sc_compress=TRUE;            /* compress bytecode? */
 SC_VDEFINE int sc_needsemicolon=TRUE;       /* semicolon required to terminate expressions? */
 SC_VDEFINE int sc_dataalign=sizeof(cell);   /* data alignment value */

--- a/source/compiler/tests/CMakeLists.txt
+++ b/source/compiler/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ set_tests_properties(gh_217 PROPERTIES PASS_REGULAR_EXPRESSION
 .*: warning 234: function is deprecated \\(symbol \"f\"\\) don't    use this     functionplease[\r\n]+\
 .*: warning 234: function is deprecated \\(symbol \"f\"\\) don't    use this     functionplease")
 
-add_compiler_test(macro_output ${CMAKE_CURRENT_SOURCE_DIR}/macro_output.pwn)
+add_compiler_test(macro_output ${CMAKE_CURRENT_SOURCE_DIR}/macro_output.pwn "-l")
 set_tests_properties(macro_output PROPERTIES PASS_REGULAR_EXPRESSION
 ".* MACRO(A->B) INPUT(A) OUTPUT(B)\
 .* MACRO(B->C) INPUT(B) OUTPUT(C)\

--- a/source/compiler/tests/CMakeLists.txt
+++ b/source/compiler/tests/CMakeLists.txt
@@ -25,6 +25,12 @@ set_tests_properties(gh_217 PROPERTIES PASS_REGULAR_EXPRESSION
 .*: warning 234: function is deprecated \\(symbol \"f\"\\) don't    use this     functionplease[\r\n]+\
 .*: warning 234: function is deprecated \\(symbol \"f\"\\) don't    use this     functionplease")
 
+add_compiler_test(macro_output ${CMAKE_CURRENT_SOURCE_DIR}/macro_output.pwn)
+set_tests_properties(macro_output PROPERTIES PASS_REGULAR_EXPRESSION
+".* MACRO(A->B) INPUT(A) OUTPUT(B)\
+.* MACRO(B->C) INPUT(B) OUTPUT(C)\
+.* MACRO(C->D) INPUT(C) OUTPUT(D)")
+
 #
 # Crashers
 #

--- a/source/compiler/tests/CMakeLists.txt
+++ b/source/compiler/tests/CMakeLists.txt
@@ -25,11 +25,12 @@ set_tests_properties(gh_217 PROPERTIES PASS_REGULAR_EXPRESSION
 .*: warning 234: function is deprecated \\(symbol \"f\"\\) don't    use this     functionplease[\r\n]+\
 .*: warning 234: function is deprecated \\(symbol \"f\"\\) don't    use this     functionplease")
 
-add_compiler_test(macro_output ${CMAKE_CURRENT_SOURCE_DIR}/macro_output.pwn "-l")
-set_tests_properties(macro_output PROPERTIES PASS_REGULAR_EXPRESSION
-".* MACRO(A->B) INPUT(A) OUTPUT(B)\
-.* MACRO(B->C) INPUT(B) OUTPUT(C)\
-.* MACRO(C->D) INPUT(C) OUTPUT(D)")
+add_compiler_test(macro_output "${CMAKE_CURRENT_SOURCE_DIR}/macro_output.pwn;-l;-m")
+set_tests_properties(macro_output PROPERTIES PASS_REGULAR_EXPRESSION 
+".* MACRO\\(A->B\\) INPUT\\(A\\) OUTPUT\\(B\\)[\r\n]+\
+.* MACRO\\(B->C\\) INPUT\\(B\\) OUTPUT\\(C\\)[\r\n]+\
+.* MACRO\\(C->D\\) INPUT\\(C\\) OUTPUT\\(D\\)")
+
 
 #
 # Crashers

--- a/source/compiler/tests/macro_output.pwn
+++ b/source/compiler/tests/macro_output.pwn
@@ -1,0 +1,5 @@
+#define A B
+#define B C
+#define C D
+
+A


### PR DESCRIPTION
Using the `-m`

* Code
```pawn
#define A B
#define B C
#define C D

A
```

* Output
```
MACRO(A->B) INPUT(A) OUTPUT(B)
MACRO(B->C) INPUT(B) OUTPUT(C)
MACRO(C->D) INPUT(C) OUTPUT(D)
```
  
ps: I don't known C, if someone know how to improve...