### PR TITLE
suggest `const` qualifier for arguments and inform user when an array/string literal is passed as a non-const argument

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4881,12 +4881,10 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
         errorset(sSETPOS,sym->lnumber);
         error(204,sym->name);       /* value assigned to symbol is never used */
         errorset(sSETPOS,-1);
-#if 0 // ??? not sure whether it is a good idea to force people use "const"
       } else if ((sym->usage & (uWRITTEN | uPUBLIC | uCONST))==0 && sym->ident==iREFARRAY) {
         errorset(sSETPOS,sym->lnumber);
         error(214,sym->name);       /* make array argument "const" */
         errorset(sSETPOS,-1);
-#endif
       } /* if */
       /* also mark the variable (local or global) to the debug information */
       if ((sym->usage & (uWRITTEN | uREAD))!=0 && (sym->usage & uNATIVE)==0)

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2274,7 +2274,8 @@ static int nesting=0;
           check_tagmismatch_multiple(arg[argidx].tags,arg[argidx].numtags,lval.tag,-1);
           if (lval.tag!=0)
             append_constval(&taglst,arg[argidx].name,lval.tag,0);
-          // ??? set uWRITTEN?
+          if (lval.sym!=NULL && (arg[argidx].usage & uCONST)==0)
+            markusage(lval.sym,uWRITTEN);
           argidx++;               /* argument done */
           break;
         } /* switch */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2214,19 +2214,23 @@ static int nesting=0;
           if (lval.sym==NULL || lval.ident==iARRAYCELL) {
             if (arg[argidx].numdim!=1) {
               error(48);        /* array dimensions must match */
-            } else if (arg[argidx].dim[0]!=0) {
-              assert(arg[argidx].dim[0]>0);
-              if (lval.ident==iARRAYCELL) {
-                error(47);        /* array sizes must match */
-              } else {
-                assert(lval.constval!=0); /* literal array must have a size */
-                /* A literal array must have exactly the same size as the
-                 * function argument; a literal string may be smaller than
-                 * the function argument.
-                 */
-                if ((lval.constval>0 && arg[argidx].dim[0]!=lval.constval)
-                    || (lval.constval<0 && arg[argidx].dim[0] < -lval.constval))
-                  error(47);      /* array sizes must match */
+            } else {
+              if (lval.sym==NULL && (arg[argidx].usage & uCONST)==0)
+                    error(239);
+              if (arg[argidx].dim[0]!=0) {
+                assert(arg[argidx].dim[0]>0);
+                if (lval.ident==iARRAYCELL) {
+                  error(7);        /* array sizes must match */
+                } else {
+                  assert(lval.constval!=0); /* literal array must have a size */
+                  /* A literal array must have exactly the same size as the
+                   * function argument; a literal string may be smaller than
+                   * the function argument.
+                   */
+                  if ((lval.constval>0 && arg[argidx].dim[0]!=lval.constval)
+                    || (lval.constval<0 && arg[argidx].dim[0]<-lval.constval))
+                    error(47);      /* array sizes must match */
+                } /* if */
               } /* if */
             } /* if */
             if (lval.ident!=iARRAYCELL || lval.constval > 0) {

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -192,7 +192,8 @@ static char *warnmsg[] = {
 /*235*/  "public function lacks forward declaration (symbol \"%s\")\n",
 /*236*/  "unknown parameter in substitution (incorrect #define pattern)\n",
 /*237*/  "user warning: %s\n",
-/*238*/  "meaningless combination of class specifiers (%s)\n"
+/*238*/  "meaningless combination of class specifiers (%s)\n",
+/*239*/  "literal array/string passed to a non-const parameter\n"
 };
 
 #define NUM_WARNINGS    (sizeof warnmsg / sizeof warnmsg[0])


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #276 

**What kind of pull this is**:

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

```
f1(arr[]) {
 	new a = arr[0];
 	#pragma unused a
}

f2(arr[5]) {
    new a = arr[0];
    #pragma unused a
}
f3(const arr[]) {
    new a = arr[0];
    #pragma unused a
}
f4(const arr[5]) {
    new a = arr[0];
    #pragma unused a
}

main () {
	f1("test");
	f2("test");
	f3("test");
	f4("test");
	
	new arr[5];
	f1(arr);
	f2(arr);
	f3(arr);
	f4(arr);
	
	f1(arr[0]);
	//f2(arr[0]); - array size must match
	f3(arr[0]);
	//f4(arr[0]); - array size must match
}
```
```
test.pwn(1) : warning 214: possibly a "const" array argument was intended: "arr"
test.pwn(6) : warning 214: possibly a "const" array argument was intended: "arr"
test.pwn(20) : warning 239: literal array/string passed to a non-const parameter
test.pwn(21) : warning 239: literal array/string passed to a non-const parameter
```
