### PR TITLE
directory default include

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -331,6 +331,11 @@ static void doinclude(int silent)
      * between <...> are only read from the list of include directories.
      */
     result=plungefile(name,(c!='>'),TRUE);
+    if(!result && (c=='>')) {
+      strlcat(name,"/default",sizeof(name));
+      result=plungefile(name,(c!='>'),TRUE);
+      name[i]='\0';
+    }
     if (result && pc_compat)
       add_constant(symname,1,sGLOBAL,0);
     else if (!result && !silent)


### PR DESCRIPTION
**[DO NOT MERGE - WORK IN PROGRESS]**
--

This commit makes the compiler look for `default.[extension]` in the given include path if the search for include file fails.

For example, <test> makes the compiler first look for test.inc in include directories. If the search fails, it then looks for `test/default.[extension]`.

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #295

**What kind of pull this is**:

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other
