### PR TITLE
provide function name in W208

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3531,7 +3531,7 @@ static void check_reparse(symbol *sym)
   if ((sym->usage & (uPROTOTYPED | uREAD))==uREAD && sym->tag!=0) {
     int curstatus=sc_status;
     sc_status=statWRITE;  /* temporarily set status to WRITE, so the warning isn't blocked */
-    error(208);
+    error(208,sym->name);
     sc_status=curstatus;
     sc_reparse=TRUE;      /* must add another pass to "initial scan" phase */
   } /* if */

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -162,7 +162,7 @@ static char *warnmsg[] = {
 /*205*/  "redundant code: constant expression is zero\n",
 /*206*/  "redundant test: constant expression is non-zero\n",
 /*207*/  "unknown #pragma\n",
-/*208*/  "function with tag result used before definition, forcing reparse\n",
+/*208*/  "function \"%s\" with tag result used before definition, forcing reparse\n",
 /*209*/  "function \"%s\" should return a value\n",
 /*210*/  "possible use of symbol before initialization: \"%s\"\n",
 /*211*/  "possibly unintended assignment\n",


### PR DESCRIPTION
**What this PR does / why we need it**:

```
main () {
	new x = f();
	#pragma unused x
}

retTag:f() {
	return retTag:0;
}
```

The warning now displays the function name: 

`warning 208: function "f" with tag result used before definition, forcing reparse`

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
