### PR TITLE
Don't generate function preamble on naked functions

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -640,7 +640,7 @@ SC_FUNC void setlinedirect(int line);
 SC_FUNC void setlineconst(int line);
 SC_FUNC void setlabel(int index);
 SC_FUNC void markexpr(optmark type,const char *name,cell offset);
-SC_FUNC void startfunc(char *fname);
+SC_FUNC void startfunc(char *fname,int generateproc);
 SC_FUNC void endfunc(void);
 SC_FUNC void alignframe(int numbytes);
 SC_FUNC void rvalue(value *lval);

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3798,7 +3798,7 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
       ptr=ptr->next;
     } /* while */
   } /* if */
-  startfunc(sym->name); /* creates stack frame */
+  startfunc(sym->name,(sym->flags & flagNAKED)==0); /* creates stack frame */
   insert_dbgline(funcline);
   setline(FALSE);
   if (sc_alignnext) {

--- a/source/compiler/sc4.c
+++ b/source/compiler/sc4.c
@@ -343,9 +343,12 @@ SC_FUNC void markexpr(optmark type,const char *name,cell offset)
  *
  *  Global references: funcstatus  (referred to only)
  */
-SC_FUNC void startfunc(char *fname)
+SC_FUNC void startfunc(char *fname,int generateproc)
 {
-  stgwrite("\tproc");
+  if (generateproc) {
+    stgwrite("\tproc");
+    code_idx+=opcodes(1);
+  } /* if */
   if (sc_asmfile) {
     char symname[2*sNAMEMAX+16];
     funcdisplayname(symname,fname);
@@ -353,7 +356,6 @@ SC_FUNC void startfunc(char *fname)
     stgwrite(symname);
   } /* if */
   stgwrite("\n");
-  code_idx+=opcodes(1);
 }
 
 /*  endfunc


### PR DESCRIPTION
**What this PR does / why we need it**:

- Skips function preamble (`PROC` instruction) on naked functions

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #324 

**What kind of pull this is**:

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
Assembly output demonstrating the new feature:

test1.pwn:
```pawn
#pragma naked
f(a)
{
    #emit LOAD.S.pri a
    #emit RETN
}

main()
{
	f(5);
}
```

test1.asm:
```asm

CODE 0	; 0
;program exit point
	halt 0

	; f
	; line 3
	;$lcl a c
	load.s.pri c
	retn 

	proc	; main
	; line 9
	; line a
	break	; 18
	push.c 5
	;$par
	push.c 4
	call .f
	;$exp
	zero.pri
	retn


STKSIZE 1000
```

test2.pwn:
```pawn
f(a)
{
    #emit LOAD.S.pri a
    #emit RETN
}

main()
{
	f(5);
}
```

test2.asm:
```asm

CODE 0	; 0
;program exit point
	halt 0

	proc	; f
	; line 2
	;$lcl a c
	load.s.pri c
	retn 
	zero.pri
	retn

	proc	; main
	; line 8
	; line 9
	break	; 24
	push.c 5
	;$par
	push.c 4
	call .f
	;$exp
	zero.pri
	retn


STKSIZE 1000
```