### PR TITLE
Show suggestions for mistyped identifiers

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -501,11 +501,19 @@ typedef struct s_emit_outval {
 /* constants for error_suggest() */
 #define MAX_EDIT_DIST 2 /* allow two mis-typed characters; when there are more,
                          * the names are too different, and no match is returned */
-enum { /* identifier types */
+enum {  /* identifier types */
   estSYMBOL = 0,
   estNONSYMBOL,
   estAUTOMATON,
   estSTATE
+};
+enum {  /* symbol types */
+  essNONLABEL,  /* find symbols of any type but labels */
+  essVARCONST,  /* array, single variable or named constant */
+  essARRAY,
+  essCONST,
+  essFUNCTN,
+  essLABEL
 };
 
 /* interface functions */

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -498,11 +498,12 @@ typedef struct s_emit_outval {
   } value;
 } emit_outval;
 
-/* Constants for error_suggest() */
+/* constants for error_suggest() */
 #define MAX_EDIT_DIST 2 /* allow two mis-typed characters; when there are more,
                          * the names are too different, and no match is returned */
 enum { /* identifier types */
   estSYMBOL = 0,
+  estNONSYMBOL,
   estAUTOMATON,
   estSTATE
 };

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -308,6 +308,11 @@ typedef struct s_valuepair {
 #define opcodes(n)      ((n)*sizeof(cell))      /* opcode size */
 #define opargs(n)       ((n)*sizeof(cell))      /* size of typical argument */
 
+/* general purpose macros */
+#if !defined makelong
+  #define makelong(low,high) ((long)(low) | ((long)(high) << (sizeof(long)*4)))
+#endif
+
 /*  Tokens recognized by lex()
  *  Some of these constants are assigned as well to the variable "lastst" (see SC1.C)
  */
@@ -492,6 +497,15 @@ typedef struct s_emit_outval {
     const char *string;
   } value;
 } emit_outval;
+
+/* Constants for error_suggest() */
+#define MAX_EDIT_DIST 2 /* allow two mis-typed characters; when there are more,
+                         * the names are too different, and no match is returned */
+enum { /* identifier types */
+  estSYMBOL = 0,
+  estAUTOMATON,
+  estSTATE
+};
 
 /* interface functions */
 #if defined __cplusplus
@@ -721,8 +735,9 @@ SC_FUNC void outval(cell val,int newline);
 SC_FUNC void outinstr(const char *name,emit_outval params[],int numparams);
 
 /* function prototypes in SC5.C */
-SC_FUNC int error(int number,...);
+SC_FUNC int error(long number,...);
 SC_FUNC void errorset(int code,int line);
+SC_FUNC int error_suggest(int error,const char *name,const char *name2,int type,int subtype);
 
 /* function prototypes in SC6.C */
 SC_FUNC int assemble(FILE *fout,FILE *fin);

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2018,7 +2018,7 @@ static void declglb(char *firstname,int firsttag,int fpublic,int fstatic,int fst
     } else {
       tag=pc_addtag(NULL);
       if (lex(&val,&str)!=tSYMBOL)      /* read in (new) token */
-        error(20,str);                  /* invalid symbol name */
+        error_suggest(20,str,NULL,estSYMBOL,iFUNCTN);   /* invalid symbol name */
       assert(strlen(str)<=sNAMEMAX);
       strcpy(name,str);                 /* save symbol name */
     } /* if */
@@ -4869,7 +4869,7 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
     case iLABEL:
       if (testlabs) {
         if ((sym->usage & uDEFINE)==0) {
-          error(19,sym->name);      /* not a label: ... */
+          error_suggest(19,sym->name,NULL,estSYMBOL,iLABEL);    /* not a label: ... */
         } else if ((sym->usage & uREAD)==0) {
           errorset(sSETPOS,sym->lnumber);
           error(203,sym->name);     /* symbol isn't used: ... */
@@ -5973,7 +5973,7 @@ static void dogoto(void)
     //     sym->compound (nesting level of the label) against nestlevel;
     //     if sym->compound < nestlevel, call the destructor operator
   } else {
-    error(20,st);       /* illegal symbol name */
+    error_suggest(20,st,NULL,estSYMBOL,iLABEL); /* illegal symbol name */
   } /* if */
   needtoken(tTERM);
 }
@@ -6013,7 +6013,7 @@ static symbol *fetchlab(char *name)
   sym=findloc(name);            /* labels are local in scope */
   if (sym) {
     if (sym->ident!=iLABEL)
-      error(19,sym->name);      /* not a label: ... */
+      error_suggest(19,sym->name,NULL,estSYMBOL,iLABEL);    /* not a label: ... */
   } else {
     sym=addsym(name,getlabel(),iLABEL,sLOCAL,0,0);
     assert(sym!=NULL);          /* fatal error 103 must be given on error */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2018,7 +2018,7 @@ static void declglb(char *firstname,int firsttag,int fpublic,int fstatic,int fst
     } else {
       tag=pc_addtag(NULL);
       if (lex(&val,&str)!=tSYMBOL)      /* read in (new) token */
-        error_suggest(20,str,NULL,estSYMBOL,iFUNCTN);   /* invalid symbol name */
+        error_suggest(20,str,NULL,estSYMBOL,essFUNCTN); /* invalid symbol name */
       assert(strlen(str)<=sNAMEMAX);
       strcpy(name,str);                 /* save symbol name */
     } /* if */
@@ -4869,7 +4869,7 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
     case iLABEL:
       if (testlabs) {
         if ((sym->usage & uDEFINE)==0) {
-          error_suggest(19,sym->name,NULL,estSYMBOL,iLABEL);    /* not a label: ... */
+          error_suggest(19,sym->name,NULL,estSYMBOL,essLABEL);  /* not a label: ... */
         } else if ((sym->usage & uREAD)==0) {
           errorset(sSETPOS,sym->lnumber);
           error(203,sym->name);     /* symbol isn't used: ... */
@@ -5973,7 +5973,7 @@ static void dogoto(void)
     //     sym->compound (nesting level of the label) against nestlevel;
     //     if sym->compound < nestlevel, call the destructor operator
   } else {
-    error_suggest(20,st,NULL,estSYMBOL,iLABEL); /* illegal symbol name */
+    error_suggest(20,st,NULL,estSYMBOL,essLABEL);   /* illegal symbol name */
   } /* if */
   needtoken(tTERM);
 }
@@ -6013,7 +6013,7 @@ static symbol *fetchlab(char *name)
   sym=findloc(name);            /* labels are local in scope */
   if (sym) {
     if (sym->ident!=iLABEL)
-      error_suggest(19,sym->name,NULL,estSYMBOL,iLABEL);    /* not a label: ... */
+      error_suggest(19,sym->name,NULL,estSYMBOL,essLABEL);  /* not a label: ... */
   } else {
     sym=addsym(name,getlabel(),iLABEL,sLOCAL,0,0);
     assert(sym!=NULL);          /* fatal error 103 must be given on error */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1854,7 +1854,7 @@ static int primary(value *lval)
          * implemented, issue an error
          */
         if ((sym->usage & uPROTOTYPED)==0)
-          error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);  /* undefined symbol */
+          error_suggest(17,st,NULL,estSYMBOL,iFUNCTN);    /* undefined symbol */
       } else {
         if ((sym->usage & uDEFINE)==0)
           error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);  /* undefined symbol */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1321,7 +1321,7 @@ static int hier2(value *lval)
       paranthese++;
     tok=lex(&val,&st);
     if (tok!=tSYMBOL)
-      return error_suggest(20,st,NULL,estSYMBOL,iVARIABLE); /* illegal symbol name */
+      return error_suggest(20,st,NULL,estNONSYMBOL,tok);    /* illegal symbol name */
     sym=findloc(st);
     if (sym==NULL)
       sym=findglb(st,sSTATEVAR);
@@ -1344,7 +1344,7 @@ static int hier2(value *lval)
       paranthese++;
     tok=lex(&val,&st);
     if (tok!=tSYMBOL)
-      return error_suggest(20,st,NULL,estSYMBOL,iVARIABLE); /* illegal symbol name */
+      return error_suggest(20,st,NULL,estNONSYMBOL,tok);    /* illegal symbol name */
     sym=findloc(st);
     if (sym==NULL)
       sym=findglb(st,sSTATEVAR);
@@ -1397,7 +1397,7 @@ static int hier2(value *lval)
       paranthese++;
     tok=lex(&val,&st);
     if (tok!=tSYMBOL && tok!=tLABEL)
-      return error_suggest(20,st,NULL,estSYMBOL,iVARIABLE); /* illegal symbol name */
+      return error_suggest(20,st,NULL,estNONSYMBOL,tok);    /* illegal symbol name */
     if (tok==tLABEL) {
       constvalue *tagsym=find_constval(&tagname_tab,st,0);
       tag=(int)((tagsym!=NULL) ? tagsym->value : 0);

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -749,7 +749,7 @@ SC_FUNC int sc_getstateid(constvalue **automaton,constvalue **state)
       return 0;
     tokeninfo(&val,&str);        /* do not copy the name yet, must check automaton first */
     if (*automaton==NULL) {
-      error(86,name);            /* unknown automaton */
+      error_suggest(86,name,NULL,estAUTOMATON,0);   /* unknown automaton */
       return 0;
     } /* if */
     assert((*automaton)->index>0);
@@ -769,7 +769,7 @@ SC_FUNC int sc_getstateid(constvalue **automaton,constvalue **state)
     char *fsaname=(*automaton)->name;
     if (*fsaname=='\0')
       fsaname="<main>";
-    error(87,name,fsaname);   /* unknown state for automaton */
+    error_suggest(87,name,fsaname,estSTATE,fsa);    /* unknown state for automaton */
     return 0;
   } /* if */
 
@@ -1321,7 +1321,7 @@ static int hier2(value *lval)
       paranthese++;
     tok=lex(&val,&st);
     if (tok!=tSYMBOL)
-      return error(20,st);      /* illegal symbol name */
+      return error_suggest(20,st,NULL,estSYMBOL,iVARIABLE); /* illegal symbol name */
     sym=findloc(st);
     if (sym==NULL)
       sym=findglb(st,sSTATEVAR);
@@ -1344,18 +1344,18 @@ static int hier2(value *lval)
       paranthese++;
     tok=lex(&val,&st);
     if (tok!=tSYMBOL)
-      return error(20,st);      /* illegal symbol name */
+      return error_suggest(20,st,NULL,estSYMBOL,iVARIABLE); /* illegal symbol name */
     sym=findloc(st);
     if (sym==NULL)
       sym=findglb(st,sSTATEVAR);
     if (sym==NULL)
-      return error(17,st);      /* undefined symbol */
+      return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE); /* undefined symbol */
     if (sym->ident==iCONSTEXPR)
       error(39);                /* constant symbol has no size */
     else if (sym->ident==iFUNCTN || sym->ident==iREFFUNC)
       error(72);                /* "function" symbol has no size */
     else if ((sym->usage & uDEFINE)==0)
-      return error(17,st);      /* undefined symbol (symbol is in the table, but it is "used" only) */
+      return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE); /* undefined symbol (symbol is in the table, but it is "used" only) */
     clear_value(lval);
     lval->ident=iCONSTEXPR;
     lval->constval=1;           /* preset */
@@ -1370,7 +1370,7 @@ static int hier2(value *lval)
           int cmptag=subsym->x.tags.index;
           tokeninfo(&val,&idxname);
           if ((idxsym=findconst(idxname,&cmptag))==NULL)
-            error(80,idxname);  /* unknown symbol, or non-constant */
+            error_suggest(80,idxname,NULL,estSYMBOL,iCONSTEXPR);    /* unknown symbol, or non-constant */
           else if (cmptag>1)
             error(91,idxname);  /* ambiguous constant */
         } /* if */
@@ -1397,7 +1397,7 @@ static int hier2(value *lval)
       paranthese++;
     tok=lex(&val,&st);
     if (tok!=tSYMBOL && tok!=tLABEL)
-      return error(20,st);      /* illegal symbol name */
+      return error_suggest(20,st,NULL,estSYMBOL,iVARIABLE); /* illegal symbol name */
     if (tok==tLABEL) {
       constvalue *tagsym=find_constval(&tagname_tab,st,0);
       tag=(int)((tagsym!=NULL) ? tagsym->value : 0);
@@ -1406,9 +1406,9 @@ static int hier2(value *lval)
       if (sym==NULL)
         sym=findglb(st,sSTATEVAR);
       if (sym==NULL)
-        return error(17,st);      /* undefined symbol */
+        return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);   /* undefined symbol */
       if ((sym->usage & uDEFINE)==0)
-        return error(17,st);      /* undefined symbol (symbol is in the table, but it is "used" only) */
+        return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);   /* undefined symbol (symbol is in the table, but it is "used" only) */
       tag=sym->tag;
     } /* if */
     if (sym!=NULL && (sym->ident==iARRAY || sym->ident==iREFARRAY)) {
@@ -1422,7 +1422,7 @@ static int hier2(value *lval)
           int cmptag=subsym->x.tags.index;
           tokeninfo(&val,&idxname);
           if ((idxsym=findconst(idxname,&cmptag))==NULL)
-            error(80,idxname);  /* unknown symbol, or non-constant */
+            error_suggest(80,idxname,NULL,estSYMBOL,iCONSTEXPR);    /* unknown symbol, or non-constant */
           else if (cmptag>1)
             error(91,idxname);  /* ambiguous constant */
         } /* if */
@@ -1601,7 +1601,7 @@ restart:
         needtoken(close);
         return FALSE;
       } else if (sym->ident!=iARRAY && sym->ident!=iREFARRAY){
-        error(28,sym->name);    /* cannot subscript, variable is not an array */
+        error_suggest(28,sym->name,NULL,estSYMBOL,iARRAY);  /* cannot subscript, variable is not an array */
         needtoken(close);
         return FALSE;
       } else if (sym->dim.array.level>0 && close!=']') {
@@ -1854,10 +1854,10 @@ static int primary(value *lval)
          * implemented, issue an error
          */
         if ((sym->usage & uPROTOTYPED)==0)
-          error(17,st);
+          error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);  /* undefined symbol */
       } else {
         if ((sym->usage & uDEFINE)==0)
-          error(17,st);
+          error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);  /* undefined symbol */
         lval->sym=sym;
         lval->ident=sym->ident;
         lval->tag=sym->tag;
@@ -1870,7 +1870,7 @@ static int primary(value *lval)
       } /* if */
     } else {
       if (!sc_allowproccall)
-        return error(17,st);    /* undefined symbol */
+        return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);   /* undefined symbol */
       /* an unknown symbol, but used in a way compatible with the "procedure
        * call" syntax. So assume that the symbol refers to a function.
        */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1349,13 +1349,13 @@ static int hier2(value *lval)
     if (sym==NULL)
       sym=findglb(st,sSTATEVAR);
     if (sym==NULL)
-      return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE); /* undefined symbol */
+      return error_suggest(17,st,NULL,estSYMBOL,essVARCONST);   /* undefined symbol */
     if (sym->ident==iCONSTEXPR)
       error(39);                /* constant symbol has no size */
     else if (sym->ident==iFUNCTN || sym->ident==iREFFUNC)
       error(72);                /* "function" symbol has no size */
     else if ((sym->usage & uDEFINE)==0)
-      return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE); /* undefined symbol (symbol is in the table, but it is "used" only) */
+      return error_suggest(17,st,NULL,estSYMBOL,essVARCONST);   /* undefined symbol (symbol is in the table, but it is "used" only) */
     clear_value(lval);
     lval->ident=iCONSTEXPR;
     lval->constval=1;           /* preset */
@@ -1370,7 +1370,7 @@ static int hier2(value *lval)
           int cmptag=subsym->x.tags.index;
           tokeninfo(&val,&idxname);
           if ((idxsym=findconst(idxname,&cmptag))==NULL)
-            error_suggest(80,idxname,NULL,estSYMBOL,iCONSTEXPR);    /* unknown symbol, or non-constant */
+            error_suggest(80,idxname,NULL,estSYMBOL,essCONST);  /* unknown symbol, or non-constant */
           else if (cmptag>1)
             error(91,idxname);  /* ambiguous constant */
         } /* if */
@@ -1406,9 +1406,9 @@ static int hier2(value *lval)
       if (sym==NULL)
         sym=findglb(st,sSTATEVAR);
       if (sym==NULL)
-        return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);   /* undefined symbol */
+        return error_suggest(17,st,NULL,estSYMBOL,essNONLABEL); /* undefined symbol */
       if ((sym->usage & uDEFINE)==0)
-        return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);   /* undefined symbol (symbol is in the table, but it is "used" only) */
+        return error_suggest(17,st,NULL,estSYMBOL,essNONLABEL); /* undefined symbol (symbol is in the table, but it is "used" only) */
       tag=sym->tag;
     } /* if */
     if (sym!=NULL && (sym->ident==iARRAY || sym->ident==iREFARRAY)) {
@@ -1422,7 +1422,7 @@ static int hier2(value *lval)
           int cmptag=subsym->x.tags.index;
           tokeninfo(&val,&idxname);
           if ((idxsym=findconst(idxname,&cmptag))==NULL)
-            error_suggest(80,idxname,NULL,estSYMBOL,iCONSTEXPR);    /* unknown symbol, or non-constant */
+            error_suggest(80,idxname,NULL,estSYMBOL,essCONST);  /* unknown symbol, or non-constant */
           else if (cmptag>1)
             error(91,idxname);  /* ambiguous constant */
         } /* if */
@@ -1601,7 +1601,7 @@ restart:
         needtoken(close);
         return FALSE;
       } else if (sym->ident!=iARRAY && sym->ident!=iREFARRAY){
-        error_suggest(28,sym->name,NULL,estSYMBOL,iARRAY);  /* cannot subscript, variable is not an array */
+        error_suggest(28,sym->name,NULL,estSYMBOL,essARRAY);/* cannot subscript, variable is not an array */
         needtoken(close);
         return FALSE;
       } else if (sym->dim.array.level>0 && close!=']') {
@@ -1854,10 +1854,10 @@ static int primary(value *lval)
          * implemented, issue an error
          */
         if ((sym->usage & uPROTOTYPED)==0)
-          error_suggest(17,st,NULL,estSYMBOL,iFUNCTN);    /* undefined symbol */
+          error_suggest(17,st,NULL,estSYMBOL,essFUNCTN);    /* undefined symbol */
       } else {
         if ((sym->usage & uDEFINE)==0)
-          error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);  /* undefined symbol */
+          error_suggest(17,st,NULL,estSYMBOL,essVARCONST);  /* undefined symbol */
         lval->sym=sym;
         lval->ident=sym->ident;
         lval->tag=sym->tag;
@@ -1870,7 +1870,7 @@ static int primary(value *lval)
       } /* if */
     } else {
       if (!sc_allowproccall)
-        return error_suggest(17,st,NULL,estSYMBOL,iVARIABLE);   /* undefined symbol */
+        return error_suggest(17,st,NULL,estSYMBOL,essVARCONST); /* undefined symbol */
       /* an unknown symbol, but used in a way compatible with the "procedure
        * call" syntax. So assume that the symbol refers to a function.
        */

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -515,7 +515,7 @@ static int find_closestsymbol_table(const char *name,const symbol *root,int symb
       ident=iARRAY;     /* reference arrays match arrays */
     else if (symboltype==iVARIABLE && (sym->ident==iCONSTEXPR || sym->ident==iREFERENCE || sym->ident==iARRAY || sym->ident==iREFARRAY))
       ident=iVARIABLE;  /* when requesting variables, constants are also ok */
-    if ((symboltype==ident || (symboltype==iVARIABLE && ident==iFUNCTN)) && ((ident!=iFUNCTN && ident!=iLABEL) || (sym->usage & uDEFINE)!=0)) {
+    if ((symboltype==ident) && ((ident!=iFUNCTN && ident!=iLABEL) || (sym->usage & uDEFINE)!=0)) {
       dist=levenshtein_distance(name,symname);
       if (dist<closestdist && dist<=maxdist) {
         *closestsym=sym;
@@ -616,7 +616,7 @@ static constvalue *findclosest_automaton_for_state(const char *statename,int fsa
         closestdist=dist;
         if (closestdist<=1)
           break;
-      } /*if */
+      } /* if */
     } /* if */
     ptr=ptr->next;
   } /* while */

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -508,6 +508,8 @@ static int find_closestsymbol_table(const char *name,const symbol *root,int symb
   assert(name!=NULL);
   maxdist=get_maxdist(name);
   for (sym=root->next; sym!=NULL; sym=sym->next) {
+    if (sym->fnumber!=-1 && sym->fnumber!=fcurrent)
+      continue;
     ident=sym->ident;
     if (symboltype==essNONLABEL) {
       if (ident==iLABEL)

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -29,6 +29,7 @@
 #if defined LINUX || defined __GNUC__
   #include <unistd.h>
 #endif
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>     /* ANSI standardized variable argument list functions */
@@ -197,6 +198,10 @@ static char *warnmsg[] = {
 /*239*/  "literal array/string passed to a non-const parameter\n"
 };
 
+static char *noticemsg[] = {
+/*001*/  "did you mean \"%s\"?"
+};
+
 #define NUM_WARNINGS    (sizeof warnmsg / sizeof warnmsg[0])
 static struct s_warnstack {
   unsigned char disable[(NUM_WARNINGS + 7) / 8]; /* 8 flags in a char */
@@ -220,13 +225,22 @@ static int errwarn;
  *                     fcurrent   (reffered to only)
  *                     errflag    (altered)
  */
-SC_FUNC int error(int number,...)
+SC_FUNC int error(long number,...)
 {
 static char *prefix[3]={ "error", "fatal error", "warning" };
 static int lastline,errorcount;
 static short lastfile;
   char *msg,*pre;
   va_list argptr;
+  char string[128];
+  int notice;
+
+  /* split the error field between the real error/warning number and an optional
+   * "notice" number
+   */
+  notice=(unsigned long)number >> (sizeof(long)*4);
+  number&=((unsigned long)~0) >> (sizeof(long)*4);
+  assert(number>0 && number<300);
 
   /* errflag is reset on each semicolon.
    * In a two-pass compiler, an error should not be reported twice. Therefore
@@ -244,24 +258,37 @@ static short lastfile;
       return 0;
   } /* if */
 
-  if (number<100){
+  if (number<100) {
+    assert(number>0 && number<(1+arraysize(errmsg)));
     msg=errmsg[number-1];
     pre=prefix[0];
     errflag=TRUE;       /* set errflag (skip rest of erroneous expression) */
     errnum++;
-  } else if (number<200){
+  } else if (number<200) {
+    assert(number>=100 && number<(100+arraysize(fatalmsg)));
     msg=fatalmsg[number-100];
     pre=prefix[1];
     errnum++;           /* a fatal error also counts as an error */
   } else if (errwarn) {
+    assert(number>=200 && number<(200+arraysize(warnmsg)));
     msg=warnmsg[number-200];
     pre=prefix[0];
     errflag=TRUE;
     errnum++;
   } else {
+    assert(number>=200 && number<(200+arraysize(warnmsg)));
     msg=warnmsg[number-200];
     pre=prefix[2];
     warnnum++;
+  } /* if */
+
+  if (notice!=0) {
+    size_t len;
+    assert(notice>0 && notice<(1+arraysize(noticemsg)));
+    strcpy(string,msg);
+    len=strlen(string);
+    sprintf(&string[len-1],"; %s\n",noticemsg[notice-1]);
+    msg=string;
   } /* if */
 
   assert(errstart<=fline);
@@ -273,7 +300,7 @@ static short lastfile;
   va_start(argptr,number);
   if (strlen(errfname)==0) {
     int start=(errstart==errline) ? -1 : errstart;
-    if (pc_error(number,msg,inpfname,start,errline,argptr)) {
+    if (pc_error((int)number,msg,inpfname,start,errline,argptr)) {
       if (outf!=NULL) {
         pc_closeasm(outf,TRUE);
         outf=NULL;
@@ -284,9 +311,9 @@ static short lastfile;
     FILE *fp=fopen(errfname,"a");
     if (fp!=NULL) {
       if (errstart>=0 && errstart!=errline)
-        fprintf(fp,"%s(%d -- %d) : %s %03d: ",inpfname,errstart,errline,pre,number);
+        fprintf(fp,"%s(%d -- %d) : %s %03d: ",inpfname,errstart,errline,pre,(int)number);
       else
-        fprintf(fp,"%s(%d) : %s %03d: ",inpfname,errline,pre,number);
+        fprintf(fp,"%s(%d) : %s %03d: ",inpfname,errline,pre,(int)number);
       vfprintf(fp,msg,argptr);
       fclose(fp);
     } /* if */
@@ -423,3 +450,173 @@ int pc_geterrorwarnings()
   return errwarn;
 }
 
+/* Implementation of Levenshtein distance, by Lorenzo Seidenari
+ */
+static int minimum(int a,int b,int c)
+{
+  int min=a;
+  if(b<min)
+    min=b;
+  if(c<min)
+    min=c;
+  return min;
+}
+
+static int levenshtein_distance(const char *s,const char*t)
+{
+  //Step 1
+  int k,i,j,cost,*d,distance;
+  int n=strlen(s);
+  int m=strlen(t);
+  assert(n>0 && m>0);
+  d=(int*)malloc((sizeof(int))*(m+1)*(n+1));
+  m++;
+  n++;
+  //Step 2
+  for (k=0;k<n;k++)
+    d[k]=k;
+  for (k=0;k<m;k++)
+    d[k*n]=k;
+  //Step 3 and 4
+  for (i=1;i<n;i++) {
+    for (j=1;j<m;j++) {
+      //Step 5
+      cost= (tolower(s[i-1])!=tolower(t[j-1]));
+      //Step 6
+      d[j*n+i]=minimum(d[(j-1)*n+i]+1,d[j*n+i-1]+1,d[(j-1)*n+i-1]+cost);
+    } /* for */
+  } /* for */
+  distance=d[n*m-1];
+  free(d);
+  return distance;
+}
+
+static int find_closestsymbol_table(const char *name,const symbol *root,int symboltype,symbol **closestsym)
+{
+  int dist,closestdist=INT_MAX;
+  char symname[2*sNAMEMAX+16];
+  symbol *sym=root->next;
+  int ident,critdist;
+
+  assert(closestsym!=NULL);
+  *closestsym=NULL;
+  assert(name!=NULL);
+  critdist=strlen(name)/2;  /* for short names, allow only a single edit */
+  if (critdist>MAX_EDIT_DIST)
+    critdist=MAX_EDIT_DIST;
+  while (sym!=NULL) {
+    funcdisplayname(symname,sym->name);
+    ident=sym->ident;
+    if (symboltype==iARRAY && ident==iREFARRAY)
+      ident=iARRAY;     /* reference arrays match arrays */
+    else if (symboltype==iVARIABLE && (sym->ident==iCONSTEXPR || sym->ident==iREFERENCE || sym->ident==iARRAY || sym->ident==iREFARRAY))
+      ident=iVARIABLE;  /* when requesting variables, constants are also ok */
+    if ((symboltype==ident || (symboltype==iVARIABLE && ident==iFUNCTN)) && ((ident!=iFUNCTN && ident!=iLABEL) || (sym->usage & uDEFINE)!=0)) {
+      dist=levenshtein_distance(name,symname);
+      if (dist<closestdist && dist<=critdist) {
+        *closestsym=sym;
+        closestdist=dist;
+      } /* if */
+    } /* if */
+    sym=sym->next;
+  } /* while */
+  return closestdist;
+}
+
+static symbol *find_closestsymbol(const char *name,int symboltype)
+{
+  symbol *symloc,*symglb;
+  int distloc,distglb;
+
+  if (sc_status==statFIRST)
+    return NULL;
+  assert(name!=NULL);
+  if (strlen(name)==0)
+    return NULL;
+  distloc=find_closestsymbol_table(name,&loctab,symboltype,&symloc);
+  if (distloc<=1)
+    distglb=INT_MAX; /* don't bother searching in the global table */
+  else
+    distglb=find_closestsymbol_table(name,&glbtab,symboltype,&symglb);
+  return (distglb<distloc) ? symglb : symloc;
+}
+
+static constvalue *find_closestautomaton(const char *name)
+{
+  constvalue *ptr=sc_automaton_tab.first;
+  constvalue *closestmatch=NULL;
+  int dist,closestdist=INT_MAX;
+
+  assert(name!=NULL);
+  while (ptr!=NULL) {
+    if (strlen(ptr->name)>0) {
+      dist=levenshtein_distance(name,ptr->name);
+      if (dist<closestdist && dist<=MAX_EDIT_DIST) {
+        closestmatch=ptr;
+        closestdist=dist;
+        if (dist<=1)
+          break;
+      } /* if */
+    } /* if */
+    ptr=ptr->next;
+  } /* while */
+  return closestmatch;
+}
+
+static constvalue *find_closeststate(const char *name,int fsa)
+{
+  constvalue *ptr=sc_state_tab.first;
+  constvalue *closestmatch=NULL;
+  int dist,closestdist=INT_MAX;
+
+  assert(name!=NULL);
+  assert(closestmatch!=NULL);
+  while (ptr!=NULL) {
+    if (ptr->index==fsa && strlen(ptr->name)>0) {
+      dist=levenshtein_distance(name,ptr->name);
+      if (dist<closestdist && dist<=MAX_EDIT_DIST) {
+        closestmatch=ptr;
+        closestdist=dist;
+      } /* if */
+    } /* if */
+    ptr=ptr->next;
+  } /* while */
+  return closestmatch;
+}
+
+SC_FUNC int error_suggest(int number,const char *name,const char *name2,int type,int subtype)
+{
+  const char *closestname=NULL;
+
+  /* don't bother finding the closest names on errors
+   * that aren't going to be shown on the 1'st pass
+   */
+  if ((errflag || sc_status!=statWRITE) && (number<100 || number>=200))
+    return 0;
+
+  if (type==estSYMBOL) {
+    symbol *closestsym=find_closestsymbol(name,subtype);
+    if (closestsym!=NULL)
+      closestname=closestsym->name;
+  } else if (type==estAUTOMATON) {
+    constvalue *closestautomaton=find_closestautomaton(name);
+    if (closestautomaton!=NULL)
+      closestname=closestautomaton->name;
+  } else if (type==estSTATE) {
+    constvalue *closestautomaton=find_closeststate(name,subtype);
+    if (closestautomaton!=NULL)
+      closestname=closestautomaton->name;
+  } else {
+    assert(0);
+  } /* if */
+
+  if (closestname!=NULL) {
+    if (name2!=NULL)
+      error(makelong(number,1),name,name2,closestname);
+    else
+      error(makelong(number,1),name,closestname);
+  } else {
+    error(number,name,name2);
+  } /* if */
+  return 0;
+}

--- a/source/compiler/tests/gh_353.inc
+++ b/source/compiler/tests/gh_353.inc
@@ -1,0 +1,2 @@
+static staticvar;
+#pragma unused staticvar

--- a/source/compiler/tests/gh_353.meta
+++ b/source/compiler/tests/gh_353.meta
@@ -1,13 +1,18 @@
 {
   'test_type': 'output_check',
   'errors': """
-gh_353.pwn(6) : error 017: undefined symbol "var"
-gh_353.pwn(9) : error 017: undefined symbol "val"; did you mean "var"?
-gh_353.pwn(11) : error 017: undefined symbol "celmax"; did you mean "cellmax"?
-gh_353.pwn(14) : error 017: undefined symbol "strcaf"; did you mean "strcat"?
-gh_353.pwn(20) : error 086: unknown automaton "dialpg"; did you mean "dialog"?
-gh_353.pwn(20) : error 036: empty statement
-gh_353.pwn(23) : error 087: unknown state "DLGLOGIN" for automaton "dialog"; did you mean "DLG_LOGIN"?
-gh_353.pwn(23) : error 036: empty statement
+gh_353.pwn(8) : error 017: undefined symbol "abcxyz"
+gh_353.pwn(17) : error 017: undefined symbol "val"; did you mean "var"?
+gh_353.pwn(21) : error 017: undefined symbol "celmax"; did you mean "cellmax"?
+gh_353.pwn(25) : error 017: undefined symbol "strcaf"; did you mean "strcat"?
+gh_353.pwn(34) : error 019: not a label: "lb"; did you mean "lbl"?
+gh_353.pwn(41) : error 020: invalid symbol name "assert"; did you mean "asset"?
+gh_353.pwn(52) : error 080: unknown symbol, or not a constant symbol (symbol "idx"); did you mean "id"?
+gh_353.pwn(63) : error 086: unknown automaton "automaton1"; did you mean "automaton_1"?
+gh_353.pwn(63) : error 036: empty statement
+gh_353.pwn(70) : error 087: unknown state "BEING1" for automaton "automaton_2"; did you mean "BEING_1"?
+gh_353.pwn(70) : error 036: empty statement
+gh_353.pwn(73) : error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
+gh_353.pwn(73) : error 036: empty statement
   """
 }

--- a/source/compiler/tests/gh_353.meta
+++ b/source/compiler/tests/gh_353.meta
@@ -1,18 +1,20 @@
 {
   'test_type': 'output_check',
   'errors': """
-gh_353.pwn(8) : error 017: undefined symbol "abcxyz"
-gh_353.pwn(17) : error 017: undefined symbol "val"; did you mean "var"?
-gh_353.pwn(21) : error 017: undefined symbol "celmax"; did you mean "cellmax"?
-gh_353.pwn(25) : error 017: undefined symbol "strcaf"; did you mean "strcat"?
-gh_353.pwn(34) : error 019: not a label: "lb"; did you mean "lbl"?
-gh_353.pwn(41) : error 020: invalid symbol name "assert"; did you mean "asset"?
-gh_353.pwn(52) : error 080: unknown symbol, or not a constant symbol (symbol "idx"); did you mean "id"?
-gh_353.pwn(63) : error 086: unknown automaton "automaton1"; did you mean "automaton_1"?
-gh_353.pwn(63) : error 036: empty statement
-gh_353.pwn(70) : error 087: unknown state "BEING1" for automaton "automaton_2"; did you mean "BEING_1"?
-gh_353.pwn(70) : error 036: empty statement
-gh_353.pwn(73) : error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
-gh_353.pwn(73) : error 036: empty statement
+gh_353.pwn(11) : error 017: undefined symbol "abcxyz"
+gh_353.pwn(19) : error 017: undefined symbol "length"
+gh_353.pwn(29) : error 017: undefined symbol "float"
+gh_353.pwn(38) : error 017: undefined symbol "val"; did you mean "var"?
+gh_353.pwn(42) : error 017: undefined symbol "celmax"; did you mean "cellmax"?
+gh_353.pwn(46) : error 017: undefined symbol "strcaf"; did you mean "strcat"?
+gh_353.pwn(55) : error 019: not a label: "lb"; did you mean "lbl"?
+gh_353.pwn(62) : error 020: invalid symbol name "assert"; did you mean "asset"?
+gh_353.pwn(73) : error 080: unknown symbol, or not a constant symbol (symbol "idx"); did you mean "id"?
+gh_353.pwn(84) : error 086: unknown automaton "automaton1"; did you mean "automaton_1"?
+gh_353.pwn(84) : error 036: empty statement
+gh_353.pwn(91) : error 087: unknown state "BEING1" for automaton "automaton_2"; did you mean "BEING_1"?
+gh_353.pwn(91) : error 036: empty statement
+gh_353.pwn(94) : error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
+gh_353.pwn(94) : error 036: empty statement
   """
 }

--- a/source/compiler/tests/gh_353.meta
+++ b/source/compiler/tests/gh_353.meta
@@ -1,20 +1,24 @@
 {
   'test_type': 'output_check',
   'errors': """
-gh_353.pwn(11) : error 017: undefined symbol "abcxyz"
-gh_353.pwn(19) : error 017: undefined symbol "length"
-gh_353.pwn(29) : error 017: undefined symbol "float"
-gh_353.pwn(38) : error 017: undefined symbol "val"; did you mean "var"?
-gh_353.pwn(42) : error 017: undefined symbol "celmax"; did you mean "cellmax"?
-gh_353.pwn(46) : error 017: undefined symbol "strcaf"; did you mean "strcat"?
-gh_353.pwn(55) : error 019: not a label: "lb"; did you mean "lbl"?
-gh_353.pwn(62) : error 020: invalid symbol name "assert"; did you mean "asset"?
-gh_353.pwn(73) : error 080: unknown symbol, or not a constant symbol (symbol "idx"); did you mean "id"?
-gh_353.pwn(84) : error 086: unknown automaton "automaton1"; did you mean "automaton_1"?
-gh_353.pwn(84) : error 036: empty statement
-gh_353.pwn(91) : error 087: unknown state "BEING1" for automaton "automaton_2"; did you mean "BEING_1"?
-gh_353.pwn(91) : error 036: empty statement
-gh_353.pwn(94) : error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
-gh_353.pwn(94) : error 036: empty statement
+gh_353.pwn(12) : error 017: undefined symbol "abcxyz"
+gh_353.pwn(20) : error 017: undefined symbol "length"
+gh_353.pwn(30) : error 017: undefined symbol "float"
+gh_353.pwn(40) : error 017: undefined symbol "ab"
+gh_353.pwn(41) : error 017: undefined symbol "ab"
+gh_353.pwn(50) : error 017: undefined symbol "staticval"
+gh_353.pwn(58) : error 017: undefined symbol "val"; did you mean "var"?
+gh_353.pwn(62) : error 017: undefined symbol "celmax"; did you mean "cellmax"?
+gh_353.pwn(66) : error 017: undefined symbol "strcaf"; did you mean "strcat"?
+gh_353.pwn(69) : error 017: undefined symbol "test_e17"; did you mean "test_e017"?
+gh_353.pwn(78) : error 019: not a label: "lb"; did you mean "lbl"?
+gh_353.pwn(85) : error 020: invalid symbol name "assert"; did you mean "asset"?
+gh_353.pwn(96) : error 080: unknown symbol, or not a constant symbol (symbol "idx"); did you mean "id"?
+gh_353.pwn(107) : error 086: unknown automaton "automaton1"; did you mean "automaton_1"?
+gh_353.pwn(107) : error 036: empty statement
+gh_353.pwn(114) : error 087: unknown state "BEING1" for automaton "automaton_2"; did you mean "BEING_1"?
+gh_353.pwn(114) : error 036: empty statement
+gh_353.pwn(117) : error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
+gh_353.pwn(117) : error 036: empty statement
   """
 }

--- a/source/compiler/tests/gh_353.meta
+++ b/source/compiler/tests/gh_353.meta
@@ -1,0 +1,13 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_353.pwn(6) : error 017: undefined symbol "var"
+gh_353.pwn(9) : error 017: undefined symbol "val"; did you mean "var"?
+gh_353.pwn(11) : error 017: undefined symbol "celmax"; did you mean "cellmax"?
+gh_353.pwn(14) : error 017: undefined symbol "strcaf"; did you mean "strcat"?
+gh_353.pwn(20) : error 086: unknown automaton "dialpg"; did you mean "dialog"?
+gh_353.pwn(20) : error 036: empty statement
+gh_353.pwn(23) : error 087: unknown state "DLGLOGIN" for automaton "dialog"; did you mean "DLG_LOGIN"?
+gh_353.pwn(23) : error 036: empty statement
+  """
+}

--- a/source/compiler/tests/gh_353.pwn
+++ b/source/compiler/tests/gh_353.pwn
@@ -1,0 +1,26 @@
+#include <console>
+#include <string>
+main()
+{
+	new var_01 = 0;		// the compiler shouldn't suggest any name for this error
+	printf("%d", var);	// since "var_01" and "var" differ by more than 2 symbols
+
+	new var = 1;
+	printf("%d", val); // error 017: undefined symbol "val"; did you mean "var"?
+
+	printf("%d", celmax); // error 017: undefined symbol "celmax"; did you mean "cellmax"?
+
+	new str[4] = "a";
+	strcaf(str, "b"); // error 017: undefined symbol "strcaf"; did you mean "strcat"?
+
+lbl:
+	goto lb; // error 019: not a label: "lb"; did you mean "lbl"?
+
+	// error 086: unknown automaton "dialpg"; did you mean "dialog"?
+	state dialpg:DLG_REGISTER;
+
+	// error 087: unknown state "DLGLOGIN" for automaton "dialog"; did you mean "DLG_LOGIN"?
+	state dialog:DLGLOGIN;
+}
+stock DialogHandler() <dialog:DLG_REGISTER> {}
+stock DialogHandler() <dialog:DLG_LOGIN> {}

--- a/source/compiler/tests/gh_353.pwn
+++ b/source/compiler/tests/gh_353.pwn
@@ -1,26 +1,74 @@
 #include <console>
 #include <string>
-main()
+
+forward test_too_different();
+public test_too_different()
 {
-	new var_01 = 0;		// the compiler shouldn't suggest any name for this error
-	printf("%d", var);	// since "var_01" and "var" differ by more than 2 symbols
-
-	new var = 1;
-	printf("%d", val); // error 017: undefined symbol "val"; did you mean "var"?
-
-	printf("%d", celmax); // error 017: undefined symbol "celmax"; did you mean "cellmax"?
-
-	new str[4] = "a";
-	strcaf(str, "b"); // error 017: undefined symbol "strcaf"; did you mean "strcat"?
-
-lbl:
-	goto lb; // error 019: not a label: "lb"; did you mean "lbl"?
-
-	// error 086: unknown automaton "dialpg"; did you mean "dialog"?
-	state dialpg:DLG_REGISTER;
-
-	// error 087: unknown state "DLGLOGIN" for automaton "dialog"; did you mean "DLG_LOGIN"?
-	state dialog:DLGLOGIN;
+	const abcd = 1;			// the compiler shouldn't suggest any name for this error
+	printf("%d\n", abcxyz);	// since "abcxyz" and "abcd" differ by more than 2 symbols
+	#pragma unused abcd
 }
-stock DialogHandler() <dialog:DLG_REGISTER> {}
-stock DialogHandler() <dialog:DLG_LOGIN> {}
+
+forward test_e017();
+public test_e017()
+{
+	// error 017: undefined symbol "val"; did you mean "var"?
+	new var = 1;
+	printf("%d\n", val);
+	#pragma unused var
+
+	// error 017: undefined symbol "celmax"; did you mean "cellmax"?
+	printf("%d\n", celmax);
+
+	// error 017: undefined symbol "strcaf"; did you mean "strcat"?
+	new str[4] = "a";
+	return strcaf(str, "b");
+}
+
+forward test_e019();
+public test_e019()
+{
+	// error 019: not a label: "lb"; did you mean "lbl"?
+lbl:
+	goto lb;
+}
+
+forward test_e020();
+public test_e020()
+{
+	// error 020: invalid symbol name "assert"; did you mean "asset"?
+	new asset = 0;
+	printf("%d\n", defined assert);
+	#pragma unused asset
+}
+
+forward test_e080();
+public test_e080()
+{
+	// error 080: unknown symbol, or not a constant symbol (symbol "idx"); did you mean "id"?
+	new values[1];
+	new idx = 0;
+	const id = 0;
+	printf("%d\n", sizeof values[idx]);
+	#pragma unused values, idx, id
+}
+
+stock func1()<automaton_1:STATE_1>{}
+stock func2()<automaton_2:BEING_1>{}
+
+forward test_e086();
+public test_e086()
+{
+	// error 086: unknown automaton "automaton1"; did you mean "automaton_1"?
+	state automaton1:STATE_1;
+}
+
+forward test_e087();
+public test_e087()
+{
+	// error 087: unknown state BEING1" for automaton "automaton_2"; did you mean "BEING_1"?
+	state automaton_2:BEING1;
+
+	// error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
+	state automaton_2:STATE_1;
+}

--- a/source/compiler/tests/gh_353.pwn
+++ b/source/compiler/tests/gh_353.pwn
@@ -1,12 +1,33 @@
 #include <console>
+#include <file>
 #include <string>
 
-forward test_too_different();
-public test_too_different()
+forward test_nosuggest1();
+public test_nosuggest1()
 {
-	const abcd = 1;			// the compiler shouldn't suggest any name for this error
-	printf("%d\n", abcxyz);	// since "abcxyz" and "abcd" differ by more than 2 symbols
+	// The compiler shouldn't suggest any name for this error
+	// since "abcxyz" and "abcd" differ by more than 2 symbols.
+	const abcd = 1;
+	printf("%d\n", abcxyz);
 	#pragma unused abcd
+}
+
+forward test_nosuggest2();
+public test_nosuggest2()
+{
+	// There are no "()" after "length", so the compiler shouldn't suggest "flength".
+	printf("%d\n", length);
+}
+
+forward test_nosuggest3();
+public test_nosuggest3()
+{
+	// float.inc is not #included, so float() is not defined.
+	// After the 1'st pass the compiler thinks float() is an unimplemented function,
+	// so it shouldn't suggest variable "flt" in this case.
+	new Float:flt;
+	return float(0);
+	#pragma unused flt
 }
 
 forward test_e017();

--- a/source/compiler/tests/gh_353.pwn
+++ b/source/compiler/tests/gh_353.pwn
@@ -1,6 +1,7 @@
 #include <console>
 #include <file>
 #include <string>
+#include "gh_353.inc"
 
 forward test_nosuggest1();
 public test_nosuggest1()
@@ -30,6 +31,25 @@ public test_nosuggest3()
 	#pragma unused flt
 }
 
+forward test_nosuggest4();
+public test_nosuggest4()
+{
+	// "abc" is a label so the compiler shouldn't suggest its name
+	// where a variable or named constant is expected.
+abc:
+	printf("%d\n", ab);
+	printf("%d\n", tagof ab);
+	#pragma unused abc
+}
+
+forward test_nosuggest5();
+public test_nosuggest5()
+{
+	// As the name suggests, variable "staticvar" is defined as static
+	// within another file, so the compiler shouldn't suggest its name here.
+	return staticval;
+}
+
 forward test_e017();
 public test_e017()
 {
@@ -43,7 +63,10 @@ public test_e017()
 
 	// error 017: undefined symbol "strcaf"; did you mean "strcat"?
 	new str[4] = "a";
-	return strcaf(str, "b");
+	strcaf(str, "b");
+
+	// error 017: undefined symbol "test_e17"; did you mean "test_e017"?
+	printf("%d\n", tagof test_e17);
 }
 
 forward test_e019();


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

Backported this feature from Pawn 3.3; it makes the compiler try to find closest names and suggest them on errors related to undefined (mistyped) identifiers. The current limit for finding close names is 2 mistyped symbols.

Here are some quick examples:
```Pawn
#include <string>
main()
{
    new var = 1;
    printf("%d", val); // error 017: undefined symbol "val"; did you mean "var"?

    printf("%d", celmax); // error 017: undefined symbol "celmax"; did you mean "cellmax"?

    new str[4] = "a";
    strcaf(str, "b"); // error 017: undefined symbol "strcaf"; did you mean "strcat"?

lbl:
    goto lb; // error 019: not a label: "lb"; did you mean "lbl"?
}
```
```Pawn
stock DialogHandler() <dialog:DLG_REGISTER> {}
stock DialogHandler() <dialog:DLG_LOGIN> {}
main()
{
    // error 086: unknown automaton "dialpg"; did you mean "dialog"?
    state dialpg:DLG_REGISTER;

    // error 087: unknown state "DLGLOGIN" for automaton "dialog"; did you mean "DLG_LOGIN"?
    state dialog:DLGLOGIN;
}
```

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->