### PR TITLE
check all definitions of a function before suggesting 'const'

### DIFF
--- a/source/compiler/tests/share_arg_flags_fstates_gh_371.meta
+++ b/source/compiler/tests/share_arg_flags_fstates_gh_371.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+share_arg_flags_fstates_gh_371.pwn(1) : warning 214: possibly a "const" array argument was intended: "str"
+share_arg_flags_fstates_gh_371.pwn(7) : warning 214: possibly a "const" array argument was intended: "str"
+"""
+}

--- a/source/compiler/tests/share_arg_flags_fstates_gh_371.pwn
+++ b/source/compiler/tests/share_arg_flags_fstates_gh_371.pwn
@@ -1,0 +1,55 @@
+f0(str[]) <fstate : a>
+{
+	new a = str[0];
+	#pragma unused a
+}
+
+f0(str[]) <fstate : b>
+{
+	new a = str[0] + str[1];
+	#pragma unused a
+}
+
+f1(str[]) <fstate : a>
+{
+	new a = str[0];
+	#pragma unused a
+}
+
+f1(str[]) <fstate : b>
+{
+	str[0] = 5;
+}
+
+f2(const str[]) <fstate : a>
+{
+	new a = str[0];
+	#pragma unused a
+}
+
+f2(const str[]) <fstate : b>
+{
+	new a = str[0] + str[1];
+	#pragma unused a
+}
+
+f3(str[]) <fstate : a>
+{
+	str[0] = 5;
+}
+
+f3(str[]) <fstate : b>
+{
+    new a = str[0];
+	#pragma unused a
+}
+
+main()
+{
+	state fstate : a;
+	new arr[10];
+	f0(arr);
+	f1(arr);
+	f2(arr);
+	f3(arr);
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`const` qualifier suggestions were being given based solely on the function definition that was currently being looked at. This caused wrong suggestions when one state of a function modifies the argument while another state did not.

The commit in this PR adds code to share usage details across multiple definitions of the functions. Hence, when the `const` qualifier is suggested, it takes into account of all the function states.

The commit is just a  proof-of-concept for the time being. The commit only shares `uWRITTEN` status only but it could be generalized to share other usage flags as well which could solve https://github.com/pawn-lang/compiler/issues/371#issuecomment-426589370

**Which issue(s) this PR fixes**:

Fixes #371 

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
