### PR TITLE
Fix the compiler suggesting unimplemented variables

### DIFF
--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -510,6 +510,8 @@ static int find_closest_symbol_table(const char *name,const symbol *root,int sym
   for (sym=root->next; sym!=NULL; sym=sym->next) {
     if (sym->fnumber!=-1 && sym->fnumber!=fcurrent)
       continue;
+    if ((sym->usage & uDEFINE)==0)
+      continue;
     ident=sym->ident;
     if (symboltype==essNONLABEL) {
       if (ident==iLABEL)
@@ -524,10 +526,10 @@ static int find_closest_symbol_table(const char *name,const symbol *root,int sym
       if (ident!=iCONSTEXPR)
         continue;
     } else if (symboltype==essFUNCTN) {
-      if ((ident!=iFUNCTN && ident!=iREFFUNC) || (sym->usage & uDEFINE)==0)
+      if (ident!=iFUNCTN && ident!=iREFFUNC)
         continue;
     } else if (symboltype==essLABEL) {
-      if (ident!=iLABEL || (sym->usage & uDEFINE)==0)
+      if (ident!=iLABEL)
         continue;
     } /* if */
     funcdisplayname(symname,sym->name);

--- a/source/compiler/tests/gh_353_symbol_suggestions.meta
+++ b/source/compiler/tests/gh_353_symbol_suggestions.meta
@@ -7,18 +7,19 @@ gh_353_symbol_suggestions.pwn(30) : error 017: undefined symbol "float"
 gh_353_symbol_suggestions.pwn(40) : error 017: undefined symbol "ab"
 gh_353_symbol_suggestions.pwn(41) : error 017: undefined symbol "ab"
 gh_353_symbol_suggestions.pwn(50) : error 017: undefined symbol "staticval"
-gh_353_symbol_suggestions.pwn(58) : error 017: undefined symbol "val"; did you mean "var"?
-gh_353_symbol_suggestions.pwn(62) : error 017: undefined symbol "celmax"; did you mean "cellmax"?
-gh_353_symbol_suggestions.pwn(66) : error 017: undefined symbol "strcaf"; did you mean "strcat"?
-gh_353_symbol_suggestions.pwn(69) : error 017: undefined symbol "test_e17"; did you mean "test_e017"?
-gh_353_symbol_suggestions.pwn(78) : error 019: not a label: "lb"; did you mean "lbl"?
-gh_353_symbol_suggestions.pwn(85) : error 020: invalid symbol name "assert"; did you mean "asset"?
-gh_353_symbol_suggestions.pwn(96) : error 080: unknown symbol, or not a constant symbol (symbol "idx"); did you mean "id"?
-gh_353_symbol_suggestions.pwn(107) : error 086: unknown automaton "automaton1"; did you mean "automaton_1"?
-gh_353_symbol_suggestions.pwn(107) : error 036: empty statement
-gh_353_symbol_suggestions.pwn(114) : error 087: unknown state "BEING1" for automaton "automaton_2"; did you mean "BEING_1"?
-gh_353_symbol_suggestions.pwn(114) : error 036: empty statement
-gh_353_symbol_suggestions.pwn(117) : error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
-gh_353_symbol_suggestions.pwn(117) : error 036: empty statement
+gh_353_symbol_suggestions.pwn(58) : error 017: undefined symbol "test_nosuggest6_val"
+gh_353_symbol_suggestions.pwn(67) : error 017: undefined symbol "val"; did you mean "var"?
+gh_353_symbol_suggestions.pwn(71) : error 017: undefined symbol "celmax"; did you mean "cellmax"?
+gh_353_symbol_suggestions.pwn(75) : error 017: undefined symbol "strcaf"; did you mean "strcat"?
+gh_353_symbol_suggestions.pwn(78) : error 017: undefined symbol "test_e17"; did you mean "test_e017"?
+gh_353_symbol_suggestions.pwn(87) : error 019: not a label: "lb"; did you mean "lbl"?
+gh_353_symbol_suggestions.pwn(94) : error 020: invalid symbol name "assert"; did you mean "asset"?
+gh_353_symbol_suggestions.pwn(105) : error 080: unknown symbol, or not a constant symbol (symbol "idx"); did you mean "id"?
+gh_353_symbol_suggestions.pwn(116) : error 086: unknown automaton "automaton1"; did you mean "automaton_1"?
+gh_353_symbol_suggestions.pwn(116) : error 036: empty statement
+gh_353_symbol_suggestions.pwn(123) : error 087: unknown state "BEING1" for automaton "automaton_2"; did you mean "BEING_1"?
+gh_353_symbol_suggestions.pwn(123) : error 036: empty statement
+gh_353_symbol_suggestions.pwn(126) : error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
+gh_353_symbol_suggestions.pwn(126) : error 036: empty statement
   """
 }

--- a/source/compiler/tests/gh_353_symbol_suggestions.pwn
+++ b/source/compiler/tests/gh_353_symbol_suggestions.pwn
@@ -50,6 +50,15 @@ public test_nosuggest5()
 	return staticval;
 }
 
+forward test_nosuggest6();
+public test_nosuggest6()
+{
+	// The compiler shouldn't suggest global variable "test_nosuggest6_val"
+	// as it's not defined yet.
+	return test_nosuggest6_val;
+}
+static test_nosuggest6_val;
+
 forward test_e017();
 public test_e017()
 {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the problem where after the 1'st pass the compiler suggests global variables before the point of their definition:
```Pawn
GetValue()
{
    return value; // error 017: undefined symbol "value"; did you mean "value"?
}

new value = 0;

main()
{
    GetValue();
}
```

**Which issue(s) this PR fixes**:

-

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

-