### PR TITLE
Branch pragma unwritten

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1238,9 +1238,13 @@ static int command(void)
             sc_tabsize=(int)val;
         } else if (strcmp(str,"align")==0) {
           sc_alignnext=TRUE;
-        } else if (strcmp(str,"unused")==0) {
+        } else if (strcmp(str,"unused")==0 || strcmp(str,"unread")==0 || strcmp(str,"unwritten")==0) {
           char name[sNAMEMAX+1];
           int i,comma;
+          /* mark as read if the pragma wasn't `unwritten` */
+          int read = str[2] == 'w' ? 0 : uREAD;
+          /* mark as written if the pragma wasn't `unread` */
+          int write = str[2] == 'r' ? 0 : uWRITTEN;
           symbol *sym;
           do {
             /* get the name */
@@ -1254,10 +1258,11 @@ static int command(void)
             if (sym==NULL)
               sym=findglb(name,sSTATEVAR);
             if (sym!=NULL) {
-              sym->usage |= uREAD;
+              /* mark as read if the pragma wasn't `unwritten` */
+              sym->usage |= read;
               if (sym->ident==iVARIABLE || sym->ident==iREFERENCE
                   || sym->ident==iARRAY || sym->ident==iREFARRAY)
-                sym->usage |= uWRITTEN;
+                sym->usage |= write;
             } else {
               error(17,name);     /* undefined symbol */
             } /* if */

--- a/source/compiler/tests/gh_373.meta
+++ b/source/compiler/tests/gh_373.meta
@@ -1,0 +1,5 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+  """
+}

--- a/source/compiler/tests/gh_373.pwn
+++ b/source/compiler/tests/gh_373.pwn
@@ -1,0 +1,11 @@
+Func(a[])
+{
+	#pragma unwritten a
+	return a[0];
+}
+
+main() {
+	new a[2];
+	Func(a);
+}
+


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

Adds `#pragma unwritten list, of, variables` and `#pragma unread more, variables`.  They are basically identical to `#pragma unused`, but only set either `uREAD` or `uWRITTEN` instead of both.  This makes intent clearer, especially when you don't write to a non-const array parameter.  This will suppress the `possibly-const` warning without the slightly odd-looking code of marking a clearly used variable as `unused`.  Basically, this just more clearly expresses intent.

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #373 
Possible solution to #371 and previous discussions (no issue number) about what to do about arrays passed to public callbacks.  Currently they are ignored.



**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
