### PR TITLE
Misc. minor fixes

### DIFF
--- a/source/compiler/memfile.c
+++ b/source/compiler/memfile.c
@@ -90,14 +90,11 @@ int memfile_write(memfile_t *mf, const void *buffer, size_t size)
 	assert(buffer != NULL);
 	if (mf->offs + size > mf->size)
 	{
-		char *orgbase = mf->base; /* save, in case realloc() fails */
 		size_t newsize = (mf->size + size) * 2;
-		mf->base = (char *)realloc(mf->base, newsize);
-		if (!mf->base)
-		{
-			mf->base = orgbase;     /* restore old pointer to avoid a memory leak */
+    char *newbase = (char *)realloc(mf->base, newsize);
+		if (!newbase)
 			return 0;
-		}
+		mf->base = newbase;
 		mf->size = newsize;
 	}
 	memcpy(mf->base + mf->offs, buffer, size);

--- a/source/compiler/memfile.c
+++ b/source/compiler/memfile.c
@@ -90,12 +90,12 @@ int memfile_write(memfile_t *mf, const void *buffer, size_t size)
 	assert(buffer != NULL);
 	if (mf->offs + size > mf->size)
 	{
-	  char *orgbase = mf->base; /* save, in case realloc() fails */
+		char *orgbase = mf->base; /* save, in case realloc() fails */
 		size_t newsize = (mf->size + size) * 2;
 		mf->base = (char *)realloc(mf->base, newsize);
 		if (!mf->base)
 		{
-		  mf->base = orgbase;     /* restore old pointer to avoid a memory leak */
+			mf->base = orgbase;     /* restore old pointer to avoid a memory leak */
 			return 0;
 		}
 		mf->size = newsize;

--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -59,6 +59,10 @@
   #define SC_FASTCALL
 #endif
 
+#if !defined strempty
+  #define strempty(str) ((str)[0]=='\0')
+#endif
+
 /* Note: the "cell" and "ucell" types are defined in AMX.H */
 
 #define PUBLIC_CHAR '@'     /* character that defines a function "public" */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -510,7 +510,7 @@ int pc_compile(int argc, char *argv[])
     set_extension(outfname,".lst",TRUE);
   else
     set_extension(outfname,".asm",TRUE);
-  if (errfname[0]!='\0')
+  if (!strempty(errfname))
     remove(errfname);   /* delete file on startup */
   else if (verbosity>0)
     setcaption();
@@ -601,7 +601,7 @@ int pc_compile(int argc, char *argv[])
     sc_status=statFIRST;        /* resetglobals() resets it to IDLE */
     setstringconstants();
     setfileconst(inpfname);
-    if (incfname[0]!='\0') {
+    if (!strempty(incfname)) {
       if (strcmp(incfname,sDEF_PREFIX)==0) {
         plungefile(incfname,FALSE,TRUE);    /* parse "default.inc" */
       } else {
@@ -625,11 +625,11 @@ int pc_compile(int argc, char *argv[])
   #if !defined SC_LIGHT
     if (sc_makereport) {
       FILE *frep=stdout;
-      if (reportname[0]!='\0')
+      if (!strempty(reportname))
         frep=fopen(reportname,"wb");    /* avoid translation of \n to \r\n in DOS/Windows */
       if (frep!=NULL) {
         make_report(&glbtab,frep,get_sourcefile(0));
-        if (reportname[0]!='\0')
+        if (!strempty(reportname))
           fclose(frep);
       } /* if */
       if (sc_documentation!=NULL) {
@@ -690,7 +690,7 @@ int pc_compile(int argc, char *argv[])
   writeleader(&glbtab);
   setfileconst(inpfname);
   insert_dbgfile(inpfname);
-  if (incfname[0]!='\0') {
+  if (!strempty(incfname)) {
     if (strcmp(incfname,sDEF_PREFIX)==0)
       plungefile(incfname,FALSE,TRUE);  /* parse "default.inc" (again) */
     else
@@ -732,7 +732,7 @@ cleanup:
   } /* if */
 
   #if !defined SC_LIGHT
-    if (errnum==0 && errfname[0]=='\0') {
+    if (errnum==0 && strempty(errfname)) {
       int recursion;
       long stacksize=max_stacksize(&glbtab,&recursion);
       int flag_exceed=0;
@@ -798,11 +798,11 @@ cleanup:
   delete_autolisttable();
   delete_heaplisttable();
   if (errnum!=0) {
-    if (errfname[0]=='\0')
+    if (strempty(errfname))
       pc_printf("\n%d Error%s.\n",errnum,(errnum>1) ? "s" : "");
     retcode=1;
   } else if (warnnum!=0){
-    if (errfname[0]=='\0')
+    if (strempty(errfname))
       pc_printf("\n%d Warning%s.\n",warnnum,(warnnum>1) ? "s" : "");
     retcode=0;          /* use "0", so that MAKE and similar tools continue */
   } else {
@@ -1150,10 +1150,10 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
           break;
         strlcpy(rname,option_value(ptr),_MAX_PATH); /* set name of report file */
         sc_makereport=TRUE;
-        if (rname[0]!='\0') {
+        if (!strempty(rname)) {
           set_extension(rname,".xml",FALSE);
         } else if ((name=get_sourcefile(0))!=NULL) {
-          assert(rname[0]=='\0');
+          assert(strempty(rname));
           assert(strlen(name)<_MAX_PATH);
           if ((ptr=strrchr(name,DIRSEP_CHAR))!=NULL)
             ptr++;          /* strip path */
@@ -1269,7 +1269,7 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
       /* The output name is the first input name with a different extension,
        * but it is stored in a different directory
        */
-      if (oname[0]=='\0') {
+      if (strempty(oname)) {
         if ((ptr=strrchr(str,DIRSEP_CHAR))!=NULL)
           ptr++;          /* strip path */
         else
@@ -1279,7 +1279,7 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
       } /* if */
       set_extension(oname,".asm",TRUE);
 #if !defined SC_LIGHT
-      if (sc_makereport && rname[0]=='\0') {
+      if (sc_makereport && strempty(rname)) {
         if ((ptr=strrchr(str,DIRSEP_CHAR))!=NULL)
           ptr++;          /* strip path */
         else
@@ -1472,7 +1472,7 @@ static void setcaption(void)
 
 static void about(void)
 {
-  if (errfname[0]=='\0') {
+  if (strempty(errfname)) {
     setcaption();
     pc_printf("Usage:   pawncc <filename> [filename...] [options]\n\n");
     pc_printf("Options:\n");
@@ -2941,7 +2941,7 @@ static void decl_enum(int vclass,int fstatic)
     needtoken(')');
   } /* if */
 
-  if (enumname[0]!='\0') {
+  if (!strempty(enumname)) {
     /* already create the root symbol, so the fields can have it as their "parent" */
     enumsym=add_constant(enumname,0,vclass,tag);
     if (enumsym!=NULL) {
@@ -3311,7 +3311,7 @@ static int operatoradjust(int opertok,symbol *sym,char *opername,int resulttag)
     error(64);        /* cannot change predefined operators */
 
   /* change the operator name */
-  assert(opername[0]!='\0');
+  assert(!strempty(opername));
   operator_symname(tmpname,opername,tags[0],tags[1],count,resulttag);
   if ((oldsym=findglb(tmpname,sGLOBAL))!=NULL) {
     int i;
@@ -3337,7 +3337,7 @@ static int operatoradjust(int opertok,symbol *sym,char *opername,int resulttag)
 
 static int check_operatortag(int opertok,int resulttag,char *opername)
 {
-  assert(opername!=NULL && opername[0]!='\0');
+  assert(opername!=NULL && !strempty(opername));
   switch (opertok) {
   case '!':
   case '<':
@@ -3800,7 +3800,7 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
   if (state_id!=0) {
     constvalue *ptr=sym->states->first;
     while (ptr!=NULL) {
-      assert(sc_status!=statWRITE || ptr->name[0]!='\0');
+      assert(sc_status!=statWRITE || !strempty(ptr->name));
       if (ptr->index==state_id) {
         setlabel((int)strtol(ptr->name,NULL,16));
         break;
@@ -4586,7 +4586,7 @@ static void make_report(symbol *root,FILE *log,char *sourcefile)
       assert(i>=0);             /* automaton 0 exists */
       stlist=automaton_findid(i);
       assert(stlist!=NULL);     /* automaton should be found */
-      fprintf(log,"\t\t\t<automaton name=\"%s\"/>\n", stlist->name[0]!='\0' ? stlist->name : "(anonymous)");
+      fprintf(log,"\t\t\t<automaton name=\"%s\"/>\n", !strempty(stlist->name) ? stlist->name : "(anonymous)");
       //??? dump state decision table
     } /* if */
     assert(sym->refer!=NULL);
@@ -4890,7 +4890,7 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
     case iFUNCTN:
       if ((sym->usage & (uDEFINE | uREAD | uNATIVE | uSTOCK | uPUBLIC))==uDEFINE) {
         funcdisplayname(symname,sym->name);
-        if (symname[0]!=0)
+        if (!strempty(symname))
           error(203,symname);       /* symbol isn't used ... (and not public/native/stock) */
       } /* if */
       if ((sym->usage & uPUBLIC)!=0 || strcmp(sym->name,uMAINFUNC)==0)
@@ -7202,7 +7202,7 @@ static void dostate(void)
   sym=findglb(uENTRYFUNC,sGLOBAL);
   if (sc_status==statWRITE && sym!=NULL && sym->ident==iFUNCTN && sym->states!=NULL) {
     for (stlist=sym->states->first; stlist!=NULL; stlist=stlist->next) {
-      assert(stlist->name[0]!='\0');
+      assert(!strempty(stlist->name));
       if (state_getfsa(stlist->index)==automaton->index && state_inlist(stlist->index,(int)state->value))
         break;      /* found! */
     } /* for */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -768,10 +768,8 @@ cleanup:
     remove(tname);         /* the "input file" was in fact a temporary file */
     free(tname);
   } /* if */
-  if (inpfname!=NULL)
-    free(inpfname);
-  if (litq!=NULL)
-    free(litq);
+  free(inpfname);
+  free(litq);
   stgbuffer_cleanup();
   clearstk();
   assert(jmpcode!=0 || loctab.next==NULL);/* on normal flow, local symbols
@@ -795,8 +793,7 @@ cleanup:
   #endif
   #if !defined SC_LIGHT
     delete_docstringtable();
-    if (sc_documentation!=NULL)
-      free(sc_documentation);
+    free(sc_documentation);
   #endif
   delete_autolisttable();
   delete_heaplisttable();
@@ -1922,8 +1919,7 @@ void sc_attachdocumentation(symbol *sym)
         assert(sym->documentation==NULL);
         sym->documentation=doc;
       } else {
-        if (sc_documentation!=NULL)
-          free(sc_documentation);
+        free(sc_documentation);
         sc_documentation=doc;
       } /* if */
     } /* if */
@@ -3087,8 +3083,7 @@ static int getstates(const char *funcname)
     /* error is already given */
     state_id=0;
   } /* if */
-  if (list!=NULL)
-    free(list);
+  free(list);
 
   return state_id;
 }

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -1450,13 +1450,15 @@ static void setconfig(char *root)
       insert_path(path);
       /* same for the codepage root */
       #if !defined NO_CODEPAGE
-        *ptr='\0';
+        if (ptr!=NULL)
+          *ptr='\0';
         if (!cp_path(path,"codepage"))
           error(109,path);        /* codepage path */
       #endif
       /* also copy the root path (for the XML documentation) */
       #if !defined SC_LIGHT
-        *ptr='\0';
+        if (ptr!=NULL)
+          *ptr='\0';
         strcpy(sc_rootpath,path);
       #endif
     } /* if */
@@ -6962,6 +6964,7 @@ static void doreturn(void)
     ident=doexpr(TRUE,FALSE,TRUE,FALSE,&tag,&sym,TRUE);
     needtoken(tTERM);
     /* see if this function already has a sub type (an array attached) */
+    assert(curfunc!=NULL);
     sub=finddepend(curfunc);
     assert(sub==NULL || sub->ident==iREFARRAY);
     if ((rettype & uRETVALUE)!=0) {
@@ -6974,7 +6977,6 @@ static void doreturn(void)
     } /* if */
     rettype|=uRETVALUE;                 /* function returns a value */
     /* check tagname with function tagname */
-    assert(curfunc!=NULL);
     check_tagmismatch(curfunc->tag,tag,TRUE,-1);
     if (ident==iARRAY || ident==iREFARRAY) {
       int dim[sDIMEN_MAX],numdim=0;
@@ -7044,8 +7046,7 @@ static void doreturn(void)
           sub=addvariable(curfunc->name,(argcount+3)*sizeof(cell),iREFARRAY,sGLOBAL,
                           curfunc->tag,dim,numdim,idxtag,0);
           sub->parent=curfunc;
-          if (curfunc)
-            curfunc->child=sub;
+          curfunc->child=sub;
         } /* if */
         /* get the hidden parameter, copy the array (the array is on the heap;
          * it stays on the heap for the moment, and it is removed -usually- at

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3615,7 +3615,7 @@ static void funcstub(int fnative)
   if (sym==NULL)
     return;
   if (fnative) {
-    sym->usage=(char)(uNATIVE | uRETVALUE | uDEFINE | (sym->usage & uPROTOTYPED));
+    sym->usage=(short)(uNATIVE | uRETVALUE | uDEFINE | (sym->usage & uPROTOTYPED));
     sym->x.lib=curlibrary;
   } else if (fpublic) {
     sym->usage|=uPUBLIC;

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4012,9 +4012,10 @@ static int declargs(symbol *sym,int chkshadow)
           error(59,name);       /* arguments of a public function may not have a default value */
         if ((sym->usage & uPROTOTYPED)==0) {
           /* redimension the argument list, add the entry */
-          sym->dim.arglist=(arginfo*)realloc(sym->dim.arglist,(argcnt+2)*sizeof(arginfo));
-          if (sym->dim.arglist==0)
+          arginfo* new_arglist=(arginfo*)realloc(sym->dim.arglist,(argcnt+2)*sizeof(arginfo));
+          if (new_arglist==NULL)
             error(103);                 /* insufficient memory */
+          sym->dim.arglist=new_arglist;
           memset(&sym->dim.arglist[argcnt+1],0,sizeof(arginfo));  /* keep the list terminated */
           sym->dim.arglist[argcnt]=arg;
         } else {
@@ -4043,9 +4044,10 @@ static int declargs(symbol *sym,int chkshadow)
           tags[numtags++]=0;            /* default tag */
         if ((sym->usage & uPROTOTYPED)==0) {
           /* redimension the argument list, add the entry iVARARGS */
-          sym->dim.arglist=(arginfo*)realloc(sym->dim.arglist,(argcnt+2)*sizeof(arginfo));
-          if (sym->dim.arglist==0)
+          arginfo* new_arglist=(arginfo*)realloc(sym->dim.arglist,(argcnt+2)*sizeof(arginfo));
+          if (new_arglist==NULL)
             error(103);                 /* insufficient memory */
+          sym->dim.arglist=new_arglist;
           memset(&sym->dim.arglist[argcnt+1],0,sizeof(arginfo));  /* keep the list terminated */
           sym->dim.arglist[argcnt].ident=iVARARGS;
           sym->dim.arglist[argcnt].hasdefault=FALSE;

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -510,7 +510,7 @@ int pc_compile(int argc, char *argv[])
     set_extension(outfname,".lst",TRUE);
   else
     set_extension(outfname,".asm",TRUE);
-  if (strlen(errfname)!=0)
+  if (errfname[0]!='\0')
     remove(errfname);   /* delete file on startup */
   else if (verbosity>0)
     setcaption();
@@ -601,7 +601,7 @@ int pc_compile(int argc, char *argv[])
     sc_status=statFIRST;        /* resetglobals() resets it to IDLE */
     setstringconstants();
     setfileconst(inpfname);
-    if (strlen(incfname)>0) {
+    if (incfname[0]!='\0') {
       if (strcmp(incfname,sDEF_PREFIX)==0) {
         plungefile(incfname,FALSE,TRUE);    /* parse "default.inc" */
       } else {
@@ -625,11 +625,11 @@ int pc_compile(int argc, char *argv[])
   #if !defined SC_LIGHT
     if (sc_makereport) {
       FILE *frep=stdout;
-      if (strlen(reportname)>0)
+      if (reportname[0]!='\0')
         frep=fopen(reportname,"wb");    /* avoid translation of \n to \r\n in DOS/Windows */
       if (frep!=NULL) {
         make_report(&glbtab,frep,get_sourcefile(0));
-        if (strlen(reportname)>0)
+        if (reportname[0]!='\0')
           fclose(frep);
       } /* if */
       if (sc_documentation!=NULL) {
@@ -690,7 +690,7 @@ int pc_compile(int argc, char *argv[])
   writeleader(&glbtab);
   setfileconst(inpfname);
   insert_dbgfile(inpfname);
-  if (strlen(incfname)>0) {
+  if (incfname[0]!='\0') {
     if (strcmp(incfname,sDEF_PREFIX)==0)
       plungefile(incfname,FALSE,TRUE);  /* parse "default.inc" (again) */
     else
@@ -732,7 +732,7 @@ cleanup:
   } /* if */
 
   #if !defined SC_LIGHT
-    if (errnum==0 && strlen(errfname)==0) {
+    if (errnum==0 && errfname[0]=='\0') {
       int recursion;
       long stacksize=max_stacksize(&glbtab,&recursion);
       int flag_exceed=0;
@@ -798,11 +798,11 @@ cleanup:
   delete_autolisttable();
   delete_heaplisttable();
   if (errnum!=0) {
-    if (strlen(errfname)==0)
+    if (errfname[0]=='\0')
       pc_printf("\n%d Error%s.\n",errnum,(errnum>1) ? "s" : "");
     retcode=1;
   } else if (warnnum!=0){
-    if (strlen(errfname)==0)
+    if (errfname[0]=='\0')
       pc_printf("\n%d Warning%s.\n",warnnum,(warnnum>1) ? "s" : "");
     retcode=0;          /* use "0", so that MAKE and similar tools continue */
   } else {
@@ -1150,10 +1150,10 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
           break;
         strlcpy(rname,option_value(ptr),_MAX_PATH); /* set name of report file */
         sc_makereport=TRUE;
-        if (strlen(rname)>0) {
+        if (rname[0]!='\0') {
           set_extension(rname,".xml",FALSE);
         } else if ((name=get_sourcefile(0))!=NULL) {
-          assert(strlen(rname)==0);
+          assert(rname[0]=='\0');
           assert(strlen(name)<_MAX_PATH);
           if ((ptr=strrchr(name,DIRSEP_CHAR))!=NULL)
             ptr++;          /* strip path */
@@ -1269,7 +1269,7 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
       /* The output name is the first input name with a different extension,
        * but it is stored in a different directory
        */
-      if (strlen(oname)==0) {
+      if (oname[0]=='\0') {
         if ((ptr=strrchr(str,DIRSEP_CHAR))!=NULL)
           ptr++;          /* strip path */
         else
@@ -1279,7 +1279,7 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
       } /* if */
       set_extension(oname,".asm",TRUE);
 #if !defined SC_LIGHT
-      if (sc_makereport && strlen(rname)==0) {
+      if (sc_makereport && rname[0]=='\0') {
         if ((ptr=strrchr(str,DIRSEP_CHAR))!=NULL)
           ptr++;          /* strip path */
         else
@@ -1470,7 +1470,7 @@ static void setcaption(void)
 
 static void about(void)
 {
-  if (strlen(errfname)==0) {
+  if (errfname[0]=='\0') {
     setcaption();
     pc_printf("Usage:   pawncc <filename> [filename...] [options]\n\n");
     pc_printf("Options:\n");
@@ -2939,7 +2939,7 @@ static void decl_enum(int vclass,int fstatic)
     needtoken(')');
   } /* if */
 
-  if (strlen(enumname)>0) {
+  if (enumname[0]!='\0') {
     /* already create the root symbol, so the fields can have it as their "parent" */
     enumsym=add_constant(enumname,0,vclass,tag);
     if (enumsym!=NULL) {
@@ -3309,7 +3309,7 @@ static int operatoradjust(int opertok,symbol *sym,char *opername,int resulttag)
     error(64);        /* cannot change predefined operators */
 
   /* change the operator name */
-  assert(strlen(opername)>0);
+  assert(opername[0]!='\0');
   operator_symname(tmpname,opername,tags[0],tags[1],count,resulttag);
   if ((oldsym=findglb(tmpname,sGLOBAL))!=NULL) {
     int i;
@@ -3335,7 +3335,7 @@ static int operatoradjust(int opertok,symbol *sym,char *opername,int resulttag)
 
 static int check_operatortag(int opertok,int resulttag,char *opername)
 {
-  assert(opername!=NULL && strlen(opername)>0);
+  assert(opername!=NULL && opername[0]!='\0');
   switch (opertok) {
   case '!':
   case '<':
@@ -3798,7 +3798,7 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
   if (state_id!=0) {
     constvalue *ptr=sym->states->first;
     while (ptr!=NULL) {
-      assert(sc_status!=statWRITE || strlen(ptr->name)>0);
+      assert(sc_status!=statWRITE || ptr->name[0]!='\0');
       if (ptr->index==state_id) {
         setlabel((int)strtol(ptr->name,NULL,16));
         break;
@@ -4584,7 +4584,7 @@ static void make_report(symbol *root,FILE *log,char *sourcefile)
       assert(i>=0);             /* automaton 0 exists */
       stlist=automaton_findid(i);
       assert(stlist!=NULL);     /* automaton should be found */
-      fprintf(log,"\t\t\t<automaton name=\"%s\"/>\n", strlen(stlist->name)>0 ? stlist->name : "(anonymous)");
+      fprintf(log,"\t\t\t<automaton name=\"%s\"/>\n", stlist->name[0]!='\0' ? stlist->name : "(anonymous)");
       //??? dump state decision table
     } /* if */
     assert(sym->refer!=NULL);
@@ -4888,7 +4888,7 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
     case iFUNCTN:
       if ((sym->usage & (uDEFINE | uREAD | uNATIVE | uSTOCK | uPUBLIC))==uDEFINE) {
         funcdisplayname(symname,sym->name);
-        if (strlen(symname)>0)
+        if (symname[0]!=0)
           error(203,symname);       /* symbol isn't used ... (and not public/native/stock) */
       } /* if */
       if ((sym->usage & uPUBLIC)!=0 || strcmp(sym->name,uMAINFUNC)==0)
@@ -7201,7 +7201,7 @@ static void dostate(void)
   sym=findglb(uENTRYFUNC,sGLOBAL);
   if (sc_status==statWRITE && sym!=NULL && sym->ident==iFUNCTN && sym->states!=NULL) {
     for (stlist=sym->states->first; stlist!=NULL; stlist=stlist->next) {
-      assert(strlen(stlist->name)!=0);
+      assert(stlist->name[0]!='\0');
       if (state_getfsa(stlist->index)==automaton->index && state_inlist(stlist->index,(int)state->value))
         break;      /* found! */
     } /* for */

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -469,7 +469,7 @@ static void stripcomment(unsigned char *line)
           if (icomment==2) {
             assert(commentidx<COMMENT_LIMIT+COMMENT_MARGIN);
             comment[commentidx]='\0';
-            if (strlen(comment)>0)
+            if (comment[0]!='\0')
               insert_docstring(comment);
           } /* if */
         #endif
@@ -576,7 +576,7 @@ static void stripcomment(unsigned char *line)
     if (icomment==2) {
       assert(commentidx<COMMENT_LIMIT+COMMENT_MARGIN);
       comment[commentidx]='\0';
-      if (strlen(comment)>0)
+      if (comment[0]!='\0')
         insert_docstring(comment);
     } /* if */
   #endif
@@ -1092,7 +1092,7 @@ static int command(void)
     if (!SKIPPING) {
       char pathname[_MAX_PATH];
       lptr=getstring((unsigned char*)pathname,sizeof pathname,lptr);
-      if (strlen(pathname)>0) {
+      if (pathname[0]!='\0') {
         free(inpfname);
         inpfname=duplicatestring(pathname);
         if (inpfname==NULL)
@@ -1183,7 +1183,7 @@ static int command(void)
               name[i]=*lptr;
             name[i]='\0';
           } /* if */
-          if (strlen(name)==0) {
+          if (name[0]=='\0') {
             curlibrary=NULL;
           } else if (strcmp(name,"-")==0) {
             pc_addlibtable=FALSE;
@@ -1508,7 +1508,7 @@ static int command(void)
         delete_subst(pattern,prefixlen);
       } /* if */
       /* add the pattern/substitution pair to the list */
-      assert(strlen(pattern)>0);
+      assert(pattern[0]!='\0');
       insert_subst(pattern,substitution,prefixlen);
       free(pattern);
       free(substitution);

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -469,7 +469,7 @@ static void stripcomment(unsigned char *line)
           if (icomment==2) {
             assert(commentidx<COMMENT_LIMIT+COMMENT_MARGIN);
             comment[commentidx]='\0';
-            if (comment[0]!='\0')
+            if (!strempty(comment))
               insert_docstring(comment);
           } /* if */
         #endif
@@ -576,7 +576,7 @@ static void stripcomment(unsigned char *line)
     if (icomment==2) {
       assert(commentidx<COMMENT_LIMIT+COMMENT_MARGIN);
       comment[commentidx]='\0';
-      if (comment[0]!='\0')
+      if (!strempty(comment))
         insert_docstring(comment);
     } /* if */
   #endif
@@ -1092,7 +1092,7 @@ static int command(void)
     if (!SKIPPING) {
       char pathname[_MAX_PATH];
       lptr=getstring((unsigned char*)pathname,sizeof pathname,lptr);
-      if (pathname[0]!='\0') {
+      if (!strempty(pathname)) {
         free(inpfname);
         inpfname=duplicatestring(pathname);
         if (inpfname==NULL)
@@ -1183,7 +1183,7 @@ static int command(void)
               name[i]=*lptr;
             name[i]='\0';
           } /* if */
-          if (name[0]=='\0') {
+          if (strempty(name)) {
             curlibrary=NULL;
           } else if (strcmp(name,"-")==0) {
             pc_addlibtable=FALSE;
@@ -1508,7 +1508,7 @@ static int command(void)
         delete_subst(pattern,prefixlen);
       } /* if */
       /* add the pattern/substitution pair to the list */
-      assert(pattern[0]!='\0');
+      assert(!strempty(pattern));
       insert_subst(pattern,substitution,prefixlen);
       free(pattern);
       free(substitution);

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -148,8 +148,10 @@ static char extensions[][6] = { "", ".inc", ".p", ".pawn" };
     error(103);                 /* insufficient memory */
   strcpy(path,name);
   real_path=(char *)malloc(strlen(name)+sizeof(extensions[0]));
-  if (real_path==NULL)
+  if (real_path==NULL) {
+    free(path);
     error(103);                 /* insufficient memory */
+  } /* if */
   do {
     found=TRUE;
     ext=strchr(path,'\0');      /* save position */
@@ -172,11 +174,13 @@ static char extensions[][6] = { "", ".inc", ".p", ".pawn" };
     if (fp==NULL) {
       *ext='\0';                /* on failure, restore filename */
       found=FALSE;
-    }
+    } /* if */
     ext_idx++;
   } while (!found && ext_idx<(sizeof extensions / sizeof extensions[0]));
   if (!found) {
     *ext='\0';                  /* restore filename */
+    free(path);
+    free(real_path);
     return FALSE;
   } /* if */
   PUSHSTK_P(inpf);

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -92,13 +92,9 @@ SC_FUNC void pushstk(stkitem val)
     int newsize= (stktop==0) ? 16 : 2*stktop;
     /* try to resize the stack */
     assert(newsize>stktop);
-    newstack=(stkitem*)malloc(newsize*sizeof(stkitem));
+    newstack=(stkitem*)realloc(stack,newsize*sizeof(stkitem));
     if (newstack==NULL)
       error(102,"parser stack");  /* stack overflow (recursive include?) */
-    /* swap the stacks */
-    memcpy(newstack,stack,stkidx*sizeof(stkitem));
-    if (stack!=NULL)
-      free(stack);
     stack=newstack;
     stktop=newsize;
   } /* if */

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1716,8 +1716,7 @@ static int substpattern(unsigned char *line,size_t buffersize,char *pattern,char
                        * a string, or the closing paranthese of a group) */
         } /* while */
         /* store the parameter (overrule any earlier) */
-        if (args[arg]!=NULL)
-          free(args[arg]);
+        free(args[arg]);
         len=(int)(e-s);
         args[arg]=(unsigned char*)malloc(len+1);
         if (args[arg]==NULL)
@@ -1819,8 +1818,7 @@ static int substpattern(unsigned char *line,size_t buffersize,char *pattern,char
   } /* if */
 
   for (arg=0; arg<10; arg++)
-    if (args[arg]!=NULL)
-      free(args[arg]);
+    free(args[arg]);
 
   return match;
 }
@@ -2909,8 +2907,7 @@ static void free_symbol(symbol *sym)
   } /* if */
   assert(sym->refer!=NULL);
   free(sym->refer);
-  if (sym->documentation!=NULL)
-    free(sym->documentation);
+  free(sym->documentation);
   if (sym->vclass==sGLOBAL)
     symbol_cache_remove(sym);
   free(sym);

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1676,7 +1676,7 @@ restart:
           cell2addr();  /* normal array index */
         } else {
           if (sym->dim.array.length!=0)
-            ffbounds(sym->dim.array.length*(32/sCHARBITS)-1);
+            ffbounds(sym->dim.array.length*((sizeof(cell)*8)/sCHARBITS)-1);
           char2addr();  /* character array index */
         } /* if */
         popreg(sALT);

--- a/source/compiler/sc4.c
+++ b/source/compiler/sc4.c
@@ -79,7 +79,7 @@ SC_FUNC void writeleader(symbol *root)
   for (fsa=sc_automaton_tab.first; fsa!=NULL; fsa=fsa->next) {
     defstorage();
     stgwrite("0\t; automaton ");
-    if (strlen(fsa->name)==0)
+    if (fsa->name[0]=='\0')
       stgwrite("(anonymous)");
     else
       stgwrite(fsa->name);
@@ -111,7 +111,7 @@ SC_FUNC void writeleader(symbol *root)
       } /* if */
       /* generate label numbers for all statelist ids */
       for (stlist=sym->states->first; stlist!=NULL; stlist=stlist->next) {
-        assert(strlen(stlist->name)==0);
+        assert(stlist->name[0]=='\0');
         strcpy(stlist->name,itoh(getlabel()));
       } /* for */
       if (strcmp(sym->name,uENTRYFUNC)==0)

--- a/source/compiler/sc4.c
+++ b/source/compiler/sc4.c
@@ -79,7 +79,7 @@ SC_FUNC void writeleader(symbol *root)
   for (fsa=sc_automaton_tab.first; fsa!=NULL; fsa=fsa->next) {
     defstorage();
     stgwrite("0\t; automaton ");
-    if (fsa->name[0]=='\0')
+    if (strempty(fsa->name))
       stgwrite("(anonymous)");
     else
       stgwrite(fsa->name);
@@ -111,7 +111,7 @@ SC_FUNC void writeleader(symbol *root)
       } /* if */
       /* generate label numbers for all statelist ids */
       for (stlist=sym->states->first; stlist!=NULL; stlist=stlist->next) {
-        assert(stlist->name[0]=='\0');
+        assert(strempty(stlist->name));
         strcpy(stlist->name,itoh(getlabel()));
       } /* for */
       if (strcmp(sym->name,uENTRYFUNC)==0)

--- a/source/compiler/sc6.c
+++ b/source/compiler/sc6.c
@@ -510,23 +510,6 @@ static cell SC_FASTCALL do_jump(FILE *fbin,char *params,cell opcode)
   return opcodes(1)+opargs(1);
 }
 
-static cell SC_FASTCALL do_switch(FILE *fbin,char *params,cell opcode)
-{
-  int i;
-  ucell p;
-
-  i=(int)hex2long(params,NULL);
-  assert(i>=0 && i<sc_labnum);
-
-  if (fbin!=NULL) {
-    assert(lbltab!=NULL);
-    p=lbltab[i];
-    write_encoded(fbin,(ucell*)&opcode,1);
-    write_encoded(fbin,&p,1);
-  } /* if */
-  return opcodes(1)+opargs(1);
-}
-
 #if defined __BORLANDC__ || defined __WATCOMC__
   #pragma argsused
 #endif
@@ -700,7 +683,7 @@ static OPCODE opcodelist[] = {
   { 80, "sub.alt",    sIN_CSEG, parm0 },
   {132, "swap.alt",   sIN_CSEG, parm0 },  /* version 4 */
   {131, "swap.pri",   sIN_CSEG, parm0 },  /* version 4 */
-  {129, "switch",     sIN_CSEG, do_switch }, /* version 1 */
+  {129, "switch",     sIN_CSEG, do_jump }, /* version 1 */
 /*{126, "symbol",     sIN_CSEG, do_symbol }, */
 /*{136, "symtag",     sIN_CSEG, parm1 },  -- version 7 */
   {123, "sysreq.c",   sIN_CSEG, parm1 },

--- a/source/compiler/sc6.c
+++ b/source/compiler/sc6.c
@@ -808,7 +808,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
   if (pc_addlibtable) {
     for (constptr=libname_tab.first; constptr!=NULL; constptr=constptr->next) {
       if (constptr->value>0) {
-        assert(strlen(constptr->name)>0);
+        assert(constptr->name[0]!='\0');
         numlibraries++;
         nametablesize+=strlen(constptr->name)+1;
       } /* if */
@@ -819,7 +819,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
   numtags=0;
   for (constptr=tagname_tab.first; constptr!=NULL; constptr=constptr->next) {
     if ((constptr->value & PUBLICTAG)!=0) {
-      assert(strlen(constptr->name)>0);
+      assert(constptr->name[0]!='\0');
       numtags++;
       nametablesize+=strlen(constptr->name)+1;
     } /* if */
@@ -945,7 +945,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
     count=0;
     for (constptr=libname_tab.first; constptr!=NULL; constptr=constptr->next) {
       if (constptr->value>0) {
-        assert(strlen(constptr->name)>0);
+        assert(constptr->name[0]!='\0');
         func.address=0;
         func.nameofs=nameofs;
         #if BYTE_ORDER==BIG_ENDIAN
@@ -989,7 +989,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
   count=0;
   for (constptr=tagname_tab.first; constptr!=NULL; constptr=constptr->next) {
     if ((constptr->value & PUBLICTAG)!=0) {
-      assert(strlen(constptr->name)>0);
+      assert(constptr->name[0]!='\0');
       func.address=constptr->value & TAGMASK;
       func.nameofs=nameofs;
       #if BYTE_ORDER==BIG_ENDIAN
@@ -1208,21 +1208,21 @@ static void append_dbginfo(FILE *fout)
 
   /* tag table */
   for (constptr=tagname_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(strlen(constptr->name)>0);
+    assert(constptr->name[0]!='\0');
     dbghdr.tags++;
     dbghdr.size+=sizeof(AMX_DBG_TAG)+strlen(constptr->name);
   } /* for */
 
   /* automaton table */
   for (constptr=sc_automaton_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(constptr->index==0 && strlen(constptr->name)==0 || strlen(constptr->name)>0);
+    assert(constptr->index==0 && constptr->name[0]=='\0' || constptr->name[0]!='\0');
     dbghdr.automatons++;
     dbghdr.size+=sizeof(AMX_DBG_MACHINE)+strlen(constptr->name);
   } /* for */
 
   /* state table */
   for (constptr=sc_state_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(strlen(constptr->name)>0);
+    assert(constptr->name[0]!='\0');
     dbghdr.states++;
     dbghdr.size+=sizeof(AMX_DBG_STATE)+strlen(constptr->name);
   } /* for */
@@ -1341,7 +1341,7 @@ static void append_dbginfo(FILE *fout)
 
   /* tag table */
   for (constptr=tagname_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(strlen(constptr->name)>0);
+    assert(constptr->name[0]!='\0');
     id1=(int16_t)(constptr->value & TAGMASK);
     #if BYTE_ORDER==BIG_ENDIAN
       align16(&id1);
@@ -1352,7 +1352,7 @@ static void append_dbginfo(FILE *fout)
 
   /* automaton table */
   for (constptr=sc_automaton_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(constptr->index==0 && strlen(constptr->name)==0 || strlen(constptr->name)>0);
+    assert(constptr->index==0 && constptr->name[0]=='\0' || constptr->name[0]!='\0');
     id1=(int16_t)constptr->index;
     address=(ucell)constptr->value;
     #if BYTE_ORDER==BIG_ENDIAN
@@ -1366,7 +1366,7 @@ static void append_dbginfo(FILE *fout)
 
   /* state table */
   for (constptr=sc_state_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(strlen(constptr->name)>0);
+    assert(constptr->name[0]!='\0');
     id1=(int16_t)constptr->value;
     id2=(int16_t)constptr->index;
     address=(ucell)constptr->value;

--- a/source/compiler/sc6.c
+++ b/source/compiler/sc6.c
@@ -1083,7 +1083,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
     } /* while */
   } /* for */
   if (bytes_out-bytes_in>0)
-    error(106);         /* compression buffer overflow */
+    longjmp(compact_err,1);
 
   if (lbltab!=NULL) {
     free(lbltab);

--- a/source/compiler/sc6.c
+++ b/source/compiler/sc6.c
@@ -808,7 +808,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
   if (pc_addlibtable) {
     for (constptr=libname_tab.first; constptr!=NULL; constptr=constptr->next) {
       if (constptr->value>0) {
-        assert(constptr->name[0]!='\0');
+        assert(!strempty(constptr->name));
         numlibraries++;
         nametablesize+=strlen(constptr->name)+1;
       } /* if */
@@ -819,7 +819,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
   numtags=0;
   for (constptr=tagname_tab.first; constptr!=NULL; constptr=constptr->next) {
     if ((constptr->value & PUBLICTAG)!=0) {
-      assert(constptr->name[0]!='\0');
+      assert(!strempty(constptr->name));
       numtags++;
       nametablesize+=strlen(constptr->name)+1;
     } /* if */
@@ -945,7 +945,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
     count=0;
     for (constptr=libname_tab.first; constptr!=NULL; constptr=constptr->next) {
       if (constptr->value>0) {
-        assert(constptr->name[0]!='\0');
+        assert(!strempty(constptr->name));
         func.address=0;
         func.nameofs=nameofs;
         #if BYTE_ORDER==BIG_ENDIAN
@@ -989,7 +989,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
   count=0;
   for (constptr=tagname_tab.first; constptr!=NULL; constptr=constptr->next) {
     if ((constptr->value & PUBLICTAG)!=0) {
-      assert(constptr->name[0]!='\0');
+      assert(!strempty(constptr->name));
       func.address=constptr->value & TAGMASK;
       func.nameofs=nameofs;
       #if BYTE_ORDER==BIG_ENDIAN
@@ -1208,21 +1208,21 @@ static void append_dbginfo(FILE *fout)
 
   /* tag table */
   for (constptr=tagname_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(constptr->name[0]!='\0');
+    assert(!strempty(constptr->name));
     dbghdr.tags++;
     dbghdr.size+=sizeof(AMX_DBG_TAG)+strlen(constptr->name);
   } /* for */
 
   /* automaton table */
   for (constptr=sc_automaton_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(constptr->index==0 && constptr->name[0]=='\0' || constptr->name[0]!='\0');
+    assert(constptr->index==0 && strempty(constptr->name) || !strempty(constptr->name));
     dbghdr.automatons++;
     dbghdr.size+=sizeof(AMX_DBG_MACHINE)+strlen(constptr->name);
   } /* for */
 
   /* state table */
   for (constptr=sc_state_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(constptr->name[0]!='\0');
+    assert(!strempty(constptr->name));
     dbghdr.states++;
     dbghdr.size+=sizeof(AMX_DBG_STATE)+strlen(constptr->name);
   } /* for */
@@ -1341,7 +1341,7 @@ static void append_dbginfo(FILE *fout)
 
   /* tag table */
   for (constptr=tagname_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(constptr->name[0]!='\0');
+    assert(!strempty(constptr->name));
     id1=(int16_t)(constptr->value & TAGMASK);
     #if BYTE_ORDER==BIG_ENDIAN
       align16(&id1);
@@ -1352,7 +1352,7 @@ static void append_dbginfo(FILE *fout)
 
   /* automaton table */
   for (constptr=sc_automaton_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(constptr->index==0 && constptr->name[0]=='\0' || constptr->name[0]!='\0');
+    assert(constptr->index==0 && strempty(constptr->name) || !strempty(constptr->name));
     id1=(int16_t)constptr->index;
     address=(ucell)constptr->value;
     #if BYTE_ORDER==BIG_ENDIAN
@@ -1366,7 +1366,7 @@ static void append_dbginfo(FILE *fout)
 
   /* state table */
   for (constptr=sc_state_tab.first; constptr!=NULL; constptr=constptr->next) {
-    assert(constptr->name[0]!='\0');
+    assert(!strempty(constptr->name));
     id1=(int16_t)constptr->value;
     id2=(int16_t)constptr->index;
     address=(ucell)constptr->value;

--- a/source/compiler/sc7.c
+++ b/source/compiler/sc7.c
@@ -1276,10 +1276,7 @@ static void grow_stgbuffer(char **buffer, int *curmax, int requiredsize)
   if (requiredsize>sSTG_MAX)
     error(102,"staging buffer");    /* staging buffer overflow (fatal error) */
   *curmax=requiredsize+sSTG_GROW;
-  if (*buffer!=NULL)
-    p=(char *)realloc(*buffer,*curmax*sizeof(char));
-  else
-    p=(char *)malloc(*curmax*sizeof(char));
+  p=(char *)realloc(*buffer,*curmax*sizeof(char));
   if (p==NULL)
     error(102,"staging buffer");    /* staging buffer overflow (fatal error) */
   *buffer=p;

--- a/source/compiler/sci18n.c
+++ b/source/compiler/sci18n.c
@@ -122,7 +122,7 @@ SC_FUNC int cp_path(const char *root, const char *directory)
   len1= (root!=NULL) ? strlen(root) : 0;
   add_slash1= (len1==0 || root[len1-1]!=DIRSEP_CHAR);
   len2= (directory!=NULL) ? strlen(directory) : 0;
-  add_slash2= (len2>0 && root[len2-1]!=DIRSEP_CHAR);
+  add_slash2= (len2>0 && directory[len2-1]!=DIRSEP_CHAR);
   if (len1+add_slash1+len2+add_slash2>=(_MAX_PATH-MAXCODEPAGE))
     return FALSE;       /* full filename may not fit */
   if (root!=NULL)

--- a/source/compiler/sclist.c
+++ b/source/compiler/sclist.c
@@ -63,10 +63,8 @@ static stringpair *insert_stringpair(stringpair *root,char *first,char *second,i
   cur->second=duplicatestring(second);
   cur->matchlength=matchlength;
   if (cur->first==NULL || cur->second==NULL) {
-    if (cur->first!=NULL)
-      free(cur->first);
-    if (cur->second!=NULL)
-      free(cur->second);
+    free(cur->first);
+    free(cur->second);
     free(cur);
     return NULL;
   } /* if */

--- a/source/compiler/scstate.c
+++ b/source/compiler/scstate.c
@@ -179,10 +179,12 @@ SC_FUNC void state_buildlist(int **list,int *listsize,int *count,int stateid)
     /* To avoid constantly calling malloc(), the list is grown by 4 states at
      * a time.
      */
+    int *newlist;
     *listsize+=4;
-    *list=(int*)realloc(*list,*listsize*sizeof(int));
-    if (*list==NULL)
+    newlist=(int*)realloc(*list,*listsize*sizeof(int));
+    if (newlist==NULL)
       error(103);               /* insufficient memory */
+    *list=newlist;
   } /* if */
 
   /* find the insertion point (the list has to stay sorted) */


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes for various minor bugs that weren't worth making a separate PR for each of them:

* Fixed invalid formula for calculating array size (in characters) in function `hier1()`.
  The cell size in bits was hardcoded as `32` (should be `sizeof(cell)*8`), which could lead to generation of invalid code for array boundary checks if the Pawn toolkit was configured with 16- or 64-bit cell size.
  Of course, this bug doesn't affect SA-MP (which is 32-bit), but I think it's still good to have this fix here.

* Fixed invalid type cast in `funcstub()`.
  See https://github.com/pawn-lang/compiler/issues/296#issuecomment-450643026.

* Fixed OOB array access in `encode_cell()`.
  This one seems to originate from a commit that I made a year and a half ago (sorry!)

* Fixed memory leaks in `plungequalifiedfile()`.
  Special thanks goes to @YashasSamaga for [reporting the bug, as well as providing a fix](https://github.com/pawn-lang/compiler/issues/296#issuecomment-449903004), though I slightly changed that fix in the following ways:
  * Moved `free(path)` before `error(103)`, because `path` won't be freed otherwise. This is because on fatal errors (1xx) `error()` returns (via `longjmp()`) directly to an error buffer set in `pc_compile`, so the code after such `error()` call is never executed.
  * For the same reason I removed two `return`s, as they are pretty much useless after `error(<fatal error code>)`.

* Removed `NULL` pointer checks before the uses of function `free()`.
  [`free()` does nothing if the pointer is `NULL`](https://en.cppreference.com/w/c/memory/free), so any `NULL` checks before the use of `free()` are redundant.

* Fixed invalid uses of `realloc()` in several places.
  The old pointer could have got leaked if the function failed to resize the old memory block or allocate a new one.

* Simplified the code in function `pushstk()` by replacing a group of calls to `malloc()`/`memcpy()`/`free()` with one `realloc()`.

* Removed function `do_switch()` (`sc6.c`).
  Apparently this function was a duplicate of `do_jump()`; it didn't implement any extra checks, so its only difference from `do_jump()` was in its name.

* Simplified string emptiness checks.
  Using `strlen(<string>)==0` to identify empty strings is inefficient because if the string is not empty `strlen()` traverses through the whole string to get its length.

* Fixed potential `NULL` pointer dereferences in functions `sc_path()` and `setconfig()`.

* Fixed incorrect error message when compact encoding is ineffective (#425).

* Other minor adjustments.

**Which issue(s) this PR fixes**:

Fixes #425

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
