### PR TITLE
Ignore `#if`d out unknown directives.

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1558,8 +1558,10 @@ static int command(void)
     } /* if */
     break;
   default:
-    error(31);          /* unknown compiler directive */
-    ret=SKIPPING ? CMD_CONDFALSE : CMD_NONE;  /* process as normal line */
+    if (!SKIPPING) {
+      error(31);          /* unknown compiler directive */
+      ret=CMD_NONE;  /* process as normal line */
+    }
   } /* switch */
   return ret;
 }


### PR DESCRIPTION
Fixes #426 

Makes the compiler slightly more future-proof by allowing us to do something like:

```pawn
#if __Pawn >= 0x03AB
    #message You're on a nice new compiler.
#endif
```

Currently to do that you need to do:

```pawnc
#message You're on a nice new compiler.
```

```pawn
#if __Pawn >= 0x03AB
    #include "message.inc"
#endif
```

Or you get an error that `#message` (or anything else) is an unknown directive if the compiler doesn't recognise it, even if it is disabled.

The only downside to this is that it makes it slightly harder to add new `#if`-like directives:

```pawn
#if __Pawn >= 0x03AB
    #message You're on a nice new compiler.
#elif SHOW_ERROR
    #error You've got an error.
#endif
```

A compiler that fails the first check AND doesn't recognise `#elif` will simply skip it and go all the way to `#endif`.  It will not evaluate it as `#elseif` and potentially run the code within.  It should somehow recognise `#elif` as a `#if`-like directive it just doesn't know and give an error.  That would require some sort of hard convention we don't yet have.  That, or we just define all possible ones now (even if they aren't implemented):

```pawn
#if
#else
#elseif
#elif
#ifdef
#elifdef
#elseifdef
#endif
#fi
#el
#ifndef
#elseifndef
#elifndef
```

Can't think of any more, but that doesn't mean there aren't any (does `iff` make any sense here?)
