### PR TITLE
Fix incorrect suggestions for state variables

### DIFF
--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -199,7 +199,8 @@ static char *warnmsg[] = {
 };
 
 static char *noticemsg[] = {
-/*001*/  "; did you mean \"%s\"?\n"
+/*001*/  "; did you mean \"%s\"?\n",
+/*002*/  "; state variable out of scope\n"
 };
 
 #define NUM_WARNINGS    (sizeof warnmsg / sizeof warnmsg[0])
@@ -660,8 +661,14 @@ SC_FUNC int error_suggest(int number,const char *name,const char *name2,int type
   if (type==estSYMBOL) {
   find_symbol:
     closest_sym=find_closest_symbol(name,subtype);
-    if (closest_sym!=NULL)
+    if (closest_sym!=NULL) {
       closest_name=closest_sym->name;
+      if ((subtype & esfVARIABLE)!=0 && closest_sym->states!=NULL && strcmp(closest_name,name)==0) {
+        assert(number==17); /* undefined symbol */
+        error(makelong(number,2),name);
+        return 0;
+      } /* if */
+    } /* if */
   } else if (type==estNONSYMBOL) {
     if (tMIDDLE<subtype && subtype<=tLAST) {
       extern char *sc_tokens[];

--- a/source/compiler/tests/gh_353_symbol_suggestions.meta
+++ b/source/compiler/tests/gh_353_symbol_suggestions.meta
@@ -24,5 +24,7 @@ gh_353_symbol_suggestions.pwn(138) : error 087: unknown state "BEING1" for autom
 gh_353_symbol_suggestions.pwn(138) : error 036: empty statement
 gh_353_symbol_suggestions.pwn(141) : error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
 gh_353_symbol_suggestions.pwn(141) : error 036: empty statement
+gh_353_symbol_suggestions.pwn(148) : error 017: undefined symbol "test_e017_sug2_var"; state variable out of scope
+gh_353_symbol_suggestions.pwn(153) : error 017: undefined symbol "test_e017_sug2_var"; state variable out of scope
   """
 }

--- a/source/compiler/tests/gh_353_symbol_suggestions.pwn
+++ b/source/compiler/tests/gh_353_symbol_suggestions.pwn
@@ -140,3 +140,19 @@ public test_e087()
 	// error 087: unknown state "STATE_1" for automaton "automaton_2"; did you mean "automaton_1:STATE_1"?
 	state automaton_2:STATE_1;
 }
+
+new test_e017_sug2_var <automaton_3:STATE_2>;
+forward test_e017_sug2();
+public test_e017_sug2()
+{
+	printf("%d\n", test_e017_sug2_var); // error 017: undefined symbol "test_e017_sug2_var"; state variable out of scope
+}
+forward test_e017_sug2_func();
+public test_e017_sug2_func() <automaton_3:STATE_1>
+{
+	printf("%d\n", test_e017_sug2_var); // error 017: undefined symbol "test_e017_sug2_var"; state variable out of scope
+}
+public test_e017_sug2_func() <automaton_3:STATE_2>
+{
+	#pragma unused test_e017_sug2_var
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes incorrect suggestions for state variables used out of state scope.

Example (from #405):
```Pawn
new var <state_a>;

main()
{
	var = 5;
}
```
Error message before the fix:
```
test.pwn(5) : error 017: undefined symbol "var"; did you mean "var"?
```
After:
```
test.pwn(5) : error 017: undefined symbol "var"; state variable out of scope
```

**Which issue(s) this PR fixes**:

Fixes #405

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**: