### PR TITLE
Fix assertion failure `glb_declared==0`

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -685,8 +685,8 @@ int pc_compile(int argc, char *argv[])
     sc_status=statSECOND;
   else
     sc_status=statWRITE;          /* allow to write --this variable was reset by resetglobals() */
-  setstringconstants();
   writeleader(&glbtab);
+  setstringconstants();
   setfileconst(inpfname);
   insert_dbgfile(inpfname);
   if (!strempty(incfname)) {


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

Fixes data for predefined arrays being put into the assembler file before everything else, which causes an assertion failure (#156).

Usually the compiler puts code/data into the assembler file in the following order:
1. The program exit point (`halt 0`).
2. (optional) The exit point for functions called from the wrong state (`halt d`).
3. (optional) Data for automatons.
4. (optional) Code for stubs and jump tables for state functions.

But if at least one of predefined string constants (`__file`, `__date`, `__time`) is used, the compiler puts their data into the assembler file before everything else, thus breaking that order.
And if there's at least one state function in the script, then assertion `glb_declared==0` in function `writeleader()` (file `sc4.c`) fails.

This bug doesn't affect the Windows build as on this OS the compiler is built without assertions, so on Windows the compiler successfully generates a valid AMX file (except for the fact that there's data before the automaton "variables", but for the VM it's still valid).

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #156 

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
