### PR TITLE
Do not allow variables to be self-assigned through initialization

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2359,7 +2359,10 @@ static int declloc(int fstatic)
         int ctag = tag;         /* set to "tag" by default */
         int explicit_init=FALSE;/* is the variable explicitly initialized? */
         if (matchtoken('=')) {
+          sym->usage &= ~uDEFINE;   /* temporarily mark the variable as undefined to prevent
+                                     * possible self-assignment through its initialization expression */
           doexpr(FALSE,FALSE,FALSE,FALSE,&ctag,NULL,TRUE);
+          sym->usage |= uDEFINE;
           explicit_init=TRUE;
         } else {
           ldconst(0,sPRI);      /* uninitialized variable, set to zero */

--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1833,6 +1833,8 @@ static int primary(value *lval)
         ldconst(0,sPRI);    /* load 0 */
         return FALSE;       /* return 0 for labels (expression error) */
       } /* if */
+      if ((sym->usage & uDEFINE)==0)
+        error_suggest(17,st,NULL,estSYMBOL,esfVARCONST);    /* undefined symbol */
       lval->sym=sym;
       lval->ident=sym->ident;
       lval->tag=sym->tag;

--- a/source/compiler/tests/gh_436_local_var_self_init.meta
+++ b/source/compiler/tests/gh_436_local_var_self_init.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_436_local_var_self_init.pwn(6) : error 017: undefined symbol "test"
+gh_436_local_var_self_init.pwn(7) : error 017: undefined symbol "test2"; did you mean "test"?
+"""
+}

--- a/source/compiler/tests/gh_436_local_var_self_init.pwn
+++ b/source/compiler/tests/gh_436_local_var_self_init.pwn
@@ -1,0 +1,9 @@
+#include <console>
+
+main()
+{
+	new arr[2];
+	new test = test;
+	new test2 = arr[test2];
+	#pragma unused test, test2
+}


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

Fixes variables being able to be self-assigned through initialization expressions (#420).
Example:
```Pawn
main()
{
	// Before the fix: no error
	// After: error 017: undefined symbol "test"
	new test = test;
}
```

The problem is that the compiler creates symbol `test` before generating the code for its initialization expression, so `test` can be used in that expression.
This PR simply makes the compiler temporarily mark the newly created symbol as undefined (until the code for the initialization expression is emitted) and issue an error if the symbol for a local variable is undefined.

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #420

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->