### PR TITLE
Re-enable warning 239 for native functions

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2216,7 +2216,7 @@ static int nesting=0;
             if (arg[argidx].numdim!=1) {
               error(48);        /* array dimensions must match */
             } else {
-              if (lval.sym==NULL && (arg[argidx].usage & uCONST)==0 && (sym->usage & uNATIVE)==0)
+              if (lval.sym==NULL && (arg[argidx].usage & uCONST)==0)
                     error(239);
               if (arg[argidx].dim[0]!=0) {
                 assert(arg[argidx].dim[0]>0);

--- a/source/compiler/tests/const_array_args_and_literals_gh_276.meta
+++ b/source/compiler/tests/const_array_args_and_literals_gh_276.meta
@@ -7,5 +7,6 @@ const_array_args_and_literals_gh_276.pwn(30) : warning 214: possibly a "const" a
 const_array_args_and_literals_gh_276.pwn(39) : warning 239: literal array/string passed to a non-const parameter
 const_array_args_and_literals_gh_276.pwn(40) : warning 239: literal array/string passed to a non-const parameter
 const_array_args_and_literals_gh_276.pwn(41) : warning 239: literal array/string passed to a non-const parameter
+const_array_args_and_literals_gh_276.pwn(60) : warning 239: literal array/string passed to a non-const parameter
 """
 }


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

A year ago warning 239 was disabled for native functions because of SA-MP functions being defined in an incorrect way.
As it was recently [highlighted in another conversation](https://github.com/pawn-lang/compiler/pull/440#issuecomment-515155836), now we have the [modified includes](https://github.com/sampctl/samp-stdlib) that fix the const-correctness issue, so we can remove that restriction from warning 239.

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->



**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [x] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
