### PR TITLE
Fix assertion failure whence the script contains a single state variable

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2078,7 +2078,7 @@ static void declglb(char *firstname,int firsttag,int fpublic,int fstatic,int fst
      */
     assert(sym==NULL
            || sym->states==NULL && sc_curstates==0
-           || sym->states!=NULL && sym->next!=NULL && sym->states->first->index==sc_curstates);
+           || sym->states!=NULL && sym->states->first!=NULL && sym->states->first->index==sc_curstates);
     /* a state variable may only have a single id in its list (so either this
      * variable has no states, or it has a single list)
      */


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

See #429 for the explanation on how to reproduce the bug.
https://github.com/pawn-lang/compiler/blob/2f642899f1eb283ea5c40143b98112eb9fc19568/source/compiler/sc1.c#L2079-L2081
It seems that the original author of this code meant to write `sym->states->next!=NULL` instead of `sym->next!=NULL` (note that in this fork the same should be written as `sym->states->first!=NULL` because we have `constvalue_root`). This is confirmed by the fact that `sym->states->first` (or `sym->states->next` in the original code) gets dereferenced right after that subexpression (`sym->states->first->index==sc_curstates`).

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #429

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
