### PR TITLE
Do not allow tags inside the braces of unnamed enums

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -2968,7 +2968,7 @@ static void decl_enum(int vclass,int fstatic)
       lexpush();
       break;
     } /* if */
-    idxtag=pc_addtag(NULL);             /* optional explicit item tag */
+    idxtag=(enumname[0]=='\0') ? tag : pc_addtag(NULL); /* optional explicit item tag */
     if (needtoken(tSYMBOL)) {           /* read in (new) token */
       tokeninfo(&val,&str);             /* get the information */
       strcpy(constname,str);            /* save symbol name */

--- a/source/compiler/tests/anonymous_enum_tags.meta
+++ b/source/compiler/tests/anonymous_enum_tags.meta
@@ -1,0 +1,7 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+anonymous_enum_tags.pwn(4) : error 001: expected token: "-identifier-", but found "-label-"
+anonymous_enum_tags.pwn(11) : error 001: expected token: "-identifier-", but found "-label-"
+  """
+}

--- a/source/compiler/tests/anonymous_enum_tags.pwn
+++ b/source/compiler/tests/anonymous_enum_tags.pwn
@@ -1,0 +1,29 @@
+enum
+{
+	CONST1,
+	Float:CONST2, // error
+	CONST3
+};
+
+enum Float:
+{
+	CONST4,
+	_:CONST5, // error
+	CONST6
+};
+
+enum eNamed1
+{
+	CONST7,
+	Float:CONST8,
+	CONST9
+};
+
+enum Float:eNamed2
+{
+	CONST10,
+	Float:CONST11,
+	CONST12
+};
+
+main(){}


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

This PR fixes a problem with the compiler silently ignoring tags inside the braces of unnamed enums.
Before:
```Pawn
enum
{
    Float:DRAW_DISTANCE = 100.0 // This code compiles, but the 'Float' tag
                                // is silently ignored and the constant is defined
                                // as "DRAW_DISTANCE = _:100.0", so if someone uses it,
                                // then instead of "100.0" they'll get "float(_:100.0)"
};
```
After:
```Pawn
enum
{
    Float:DRAW_DISTANCE = 100.0 // error 001: expected token: "-identifier-", but found "-label-"
};
```

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #444

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
