### PR TITLE
enum continuation

### DIFF
--- a/source/compiler/tests/continue_enum.meta
+++ b/source/compiler/tests/continue_enum.meta
@@ -1,0 +1,11 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+continue_enum.pwn(36) : error 001: expected token: "-identifier-", but found "{"
+continue_enum.pwn(41) : error 001: expected token: "-identifier-", but found "{"
+continue_enum.pwn(45) : error 024: "break" or "continue" is out of context
+continue_enum.pwn(55) : error 024: "break" or "continue" is out of context
+continue_enum.pwn(55) : error 001: expected token: ";", but found "enum"
+continue_enum.pwn(56) : error 021: symbol already defined: "dialogid"
+  """
+}

--- a/source/compiler/tests/continue_enum.pwn
+++ b/source/compiler/tests/continue_enum.pwn
@@ -1,0 +1,62 @@
+#pragma option -d1 // for #assert
+#pragma option -;+
+
+enum myenum
+{
+	CONST1 = 1,
+	CONST2, // 2
+	CONST3  // 3
+};
+
+enum continue myenum (+= 2)
+{
+	CONST4, // 4
+	CONST6  // 6
+};
+#assert CONST4 == 4
+#assert CONST6 == 6
+
+continue enum myenum (*= 3)
+{
+	CONST8, // 8
+	CONST24 // 24
+};
+#assert CONST8 == 8
+#assert CONST24 == 24
+
+
+enum // anonymous enumeration
+{
+	ACONST1 = 1,
+	ACONST2, // 2
+	ACONST3  // 3
+};
+
+enum continue // error (no enum name)
+{
+	ACONST4
+};
+
+continue enum // error (no enum name)
+{
+	ACONST5
+};
+
+continue; // error ('continue' used out of context)
+
+continue enum dialogid // the 'continue' keyword is pretty much ignored here
+{
+	DIALOG_NONE
+};
+
+public Func1();
+public Func1()
+{
+	continue enum dialogid // error (enum continuation doesn't work inside functions)
+	{
+		DIALOG_ID1
+	};
+	#pragma unused DIALOG_ID1
+}
+
+main(){}


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

This PR adds an ability to continue previously defined enumerations.
Example:
```Pawn
enum dialogid // note that the tag 'dialogid' is weak (starts with a lowercase letter)
{             // so tag override isn't required when using the constants from this enum
    DIALOG_ID_NONE = 0
};

continue enum dialogid // continue the enumeration
{
    DIALOGID_REGISTER, // 1
    DIALOGID_LOGIN     // 2
};

enum continue dialogid // 'enum continue' is also valid
{
    DIALOGID_HELP,     // 3
    DIALOGID_RULES     // 4
};
```
This could be used in different scenarios. The most obvious one, as shown above, is to define SA-MP dialog IDs in different source files for better modularity.

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->

* Specifying a enum name after `continue enum`/`enum continue` is mandatory (or else how would the compiler know which enum to continue?)
```Pawn
enum continue // error (no enum name)
{
    // ...
};
```
* The first enum in the continuation chain can also be defined via `continue enum`/`enum continue`.
```Pawn
#include <a_samp>

continue enum dialogid // enum 'dialogid' wasn't previously defined, so the compiler
{                      // would simply create a new one and ignore the 'continue' keyword
    DIALOG_ID_NONE // 0
};
```
* Enum continuation can't be used inside functions.
* `continue enum`/`enum continue` can't be combined with static enumerations ( `static enum`/`enum static`).
