### PR TITLE
elaborated on contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # Contributing to the Pawn Compiler
 
-When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
-
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+If you are proposing a new feature or fixing a bug of significant complexity, please do not write any code and propose your planned changes via an issue first! This saves _you_ time in case changes are required or the feature is rejected and it saves the _maintainers_ time as discussing proposals is generally easier than doing code review. Thank you!
 
 ## Pull Requests
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,11 @@ Never pull to `master` - always pull to `dev` or a relevant feature branch.
 
 **Which issue(s) this PR fixes**:
 
-<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->
+<!--
+Please ensure you have discussed your proposed changes before committing time to writing code!
+
+GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged
+-->
 
 Fixes #
 

--- a/readme.md
+++ b/readme.md
@@ -80,10 +80,12 @@ can easily install the compiler on your distribution. Please follow these steps:
 
 If you are a [sampctl][sampctl] user, you are already using this compiler!
 
-### Build From Source
+### Building from Source
 
-If you are interested in contributing or just using a specific version, check
-out [this page][build_source] for instructions for compiling for your platform.
+If you are interested in contributing then please first read
+[this document][contributing] and ensure you have discussed your proposed
+changes before writing any code. Check out [this page][build_source] for
+instructions for compiling for your platform.
 
 ## Background
 
@@ -116,4 +118,6 @@ seems to be based on an older release of Pawn.
   https://ci.appveyor.com/project/Southclaws/compiler/branch/master/artifacts
 [compat]: https://github.com/pawn-lang/compiler/wiki/Compatibility-mode
 [sampctl]: http://bit.ly/sampctl
+[contributing]:
+  https://github.com/pawn-lang/compiler/tree/master/.github/CONTRIBUTING.md
 [build_source]: https://github.com/pawn-lang/compiler/wiki/Building-From-Source


### PR DESCRIPTION
This change just improves the wording around contribution in the readme, contributing and PR template to ensure contributors discuss proposed changes before actually writing any code to save time during code review.
