### PR TITLE
fix "#pragma option" crash when character count is over 31

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1342,14 +1342,9 @@ static int command(void)
           /* first gather all information, start with the tag name */
           while (*lptr<=' ' && *lptr!='\0')
             lptr++;
-          for (i=0; i<sizeof name && *lptr>' '; i++,lptr++)
+          for (i=0; i<sNAMEMAX && *lptr>' '; i++,lptr++)
             name[i]=*lptr;
-          /* check if 'i' is 32 or not to prevent OOB */
-          if (i==sNAMEMAX+1) {
-            name[i-1]='\0';
-          } else {
-            name[i]='\0';
-          }
+          name[i]='\0';
           parsesingleoption(name);
         } else {
           error(207);           /* unknown #pragma */

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1344,7 +1344,12 @@ static int command(void)
             lptr++;
           for (i=0; i<sizeof name && *lptr>' '; i++,lptr++)
             name[i]=*lptr;
-          name[i-1]='\0';
+          /* check if 'i' is 32 or not to prevent OOB */
+          if (i==sNAMEMAX+1) {
+            name[i-1]='\0';
+          } else {
+            name[i]='\0';
+          }
           parsesingleoption(name);
         } else {
           error(207);           /* unknown #pragma */

--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1344,7 +1344,7 @@ static int command(void)
             lptr++;
           for (i=0; i<sizeof name && *lptr>' '; i++,lptr++)
             name[i]=*lptr;
-          name[i]='\0';
+          name[i-1]='\0';
           parsesingleoption(name);
         } else {
           error(207);           /* unknown #pragma */


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

- Title says it all!

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #359

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->

For some reason `i` will be `32` after our for loop so an OOB happens when code tries to assign `'\0'` to `name[32]` since `name` size is 32.
Doing a `-1` to `i` fixed this issue and now throws 
```
error 038: extra characters on line
```
when character count is over 31.

Also I'm not sure if I should change `name` size and make it able to accept more than 31 characters, since file paths can be more than 31 characters of course
