### PR TITLE
Check switch/case values for tag mismatch

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5900,9 +5900,10 @@ static void doswitch(void)
           caselist.first=newval;
         if (matchtoken(tDBLDOT)) {
           cell end;
-          constexpr(&end,NULL,NULL);
+          constexpr(&end,&csetag,NULL);
           if (end<=val)
             error(50);                  /* invalid range */
+          check_tagmismatch(swtag,csetag,TRUE,-1);
           while (++val<=end) {
             casecount++;
             /* find the new insertion point */

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -5828,6 +5828,7 @@ static void doswitch(void)
   int lbl_table,lbl_exit,lbl_case;
   int swdefault,casecount;
   int tok,endtok;
+  int swtag,csetag;
   cell val;
   char *str;
   constvalue_root caselist = { NULL, NULL};   /* case list starts empty */
@@ -5835,7 +5836,7 @@ static void doswitch(void)
   char labelname[sNAMEMAX+1];
 
   endtok= matchtoken('(') ? ')' : tDO;
-  doexpr(TRUE,FALSE,FALSE,FALSE,NULL,NULL,TRUE);/* evaluate switch expression */
+  doexpr(TRUE,FALSE,FALSE,FALSE,&swtag,NULL,TRUE);/* evaluate switch expression */
   needtoken(endtok);
   /* generate the code for the switch statement, the label is the address
    * of the case table (to be generated later).
@@ -5874,7 +5875,8 @@ static void doswitch(void)
          *     parse all expressions until that special token.
          */
 
-        constexpr(&val,NULL,NULL);
+        constexpr(&val,&csetag,NULL);
+        check_tagmismatch(swtag,csetag,TRUE,-1);
         /* Search the insertion point (the table is kept in sorted order, so
          * that advanced abstract machines can sift the case table with a
          * binary search). Check for duplicate case values at the same time.

--- a/source/compiler/tests/switch-case-tag-control.meta
+++ b/source/compiler/tests/switch-case-tag-control.meta
@@ -4,5 +4,6 @@
 switch-case-tag-control.pwn(10) : warning 213: tag mismatch: expected tag none ("_"), but found "Float"
 switch-case-tag-control.pwn(16) : warning 213: tag mismatch: expected tag "Float", but found "bool"
 switch-case-tag-control.pwn(17) : warning 213: tag mismatch: expected tag "Float", but found none ("_")
+switch-case-tag-control.pwn(24) : warning 213: tag mismatch: expected tag none ("_"), but found "Tag"
 """
 }

--- a/source/compiler/tests/switch-case-tag-control.meta
+++ b/source/compiler/tests/switch-case-tag-control.meta
@@ -1,0 +1,8 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+switch-case-tag-control.pwn(10) : warning 213: tag mismatch: expected tag none ("_"), but found "Float"
+switch-case-tag-control.pwn(16) : warning 213: tag mismatch: expected tag "Float", but found "bool"
+switch-case-tag-control.pwn(17) : warning 213: tag mismatch: expected tag "Float", but found none ("_")
+"""
+}

--- a/source/compiler/tests/switch-case-tag-control.pwn
+++ b/source/compiler/tests/switch-case-tag-control.pwn
@@ -1,0 +1,19 @@
+#include <float>
+
+main()
+{
+	new x = 0;
+	switch (x)
+	{
+		case 0: {} // no tag (ok)
+		case true: {} // bool (should work since "bool" is a weak tag)
+		case 2.0: {} // Float: (tag mismatch; "Float" is a strong tag)
+	}
+	new Float:f = 0.0;
+	switch (f)
+	{
+		case 0.0: {} // Float (ok)
+		case true: {} // bool (tag mismatch)
+		case 2: {} // no tag (tag mismatch)
+	}
+}

--- a/source/compiler/tests/switch-case-tag-control.pwn
+++ b/source/compiler/tests/switch-case-tag-control.pwn
@@ -16,4 +16,11 @@ main()
 		case true: {} // bool (tag mismatch)
 		case 2: {} // no tag (tag mismatch)
 	}
+	const Tag:THREE = Tag:3;
+	switch (x)
+	{
+		case -2 .. -1: {} // no tag (ok)
+		case 0 .. true: {} // bool (should work since "bool" is a weak tag)
+		case 2 .. THREE: {} // Tag: (tag mismatch; "Tag" is a strong tag)
+	}
 }


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

Fixes an oversight with the compiler not checking the `switch`/`case` values for tag mismatch, as described in #468.

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #468 

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
