### PR TITLE
Tagof tag argdefault

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -249,6 +249,7 @@ typedef struct s_symbol {
 #define flagNAKED     0x10  /* function is naked */
 #define flagPREDEF    0x20  /* symbol is pre-defined; successor of uPREDEF */
 
+#define uTAGOF_TAG 0x20  /* set in the "hasdefault" field of the arginfo struct */
 #define uTAGOF    0x40  /* set in the "hasdefault" field of the arginfo struct */
 #define uSIZEOF   0x80  /* set in the "hasdefault" field of the arginfo struct */
 

--- a/source/compiler/tests/tagof_tag_argdefault.meta
+++ b/source/compiler/tests/tagof_tag_argdefault.meta
@@ -1,0 +1,5 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+"""
+}

--- a/source/compiler/tests/tagof_tag_argdefault.pwn
+++ b/source/compiler/tests/tagof_tag_argdefault.pwn
@@ -1,0 +1,24 @@
+#include <float>
+
+// Tag `Float:` is already defined at this moment, so `tagof(Float:)` should
+// evaluate to the same value on both the 1'st and the 2'nd compiler passes.
+Func1(a = tagof(Float:))
+	return a;
+
+// `tagof(Tag:)` returns 0 on the 1'st pass since `Tag:` is not defined yet,
+// but it gets defined later (see function `main()`), so on the 2'nd pass
+// `tagof(Tag:)` evaluates to a nonzero value, thus causing "error 025: function
+// heading differs from prototype". This is solved by ignoring the different
+// default values and overriding the old default value obtained at the previous
+// function definition with the new one from the current definition when `tagof`
+// is used on a tag.
+Func2(a = tagof(Tag:))
+	return a;
+
+main()
+{
+	new Tag:t = Tag:0;
+	#pragma unused t
+	Func1();
+	Func2();
+}


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

Allows to use `tagof(Tag:)` as a default value for function arguments (see #485).

**Which issue(s) this PR fixes**:

<!--GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged-->

Fixes #485

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
