### PR TITLE
Fix incorrect error message (007 => 047)

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -2341,7 +2341,7 @@ static int nesting=0;
               if (arg[argidx].dim[0]!=0) {
                 assert(arg[argidx].dim[0]>0);
                 if (lval.ident==iARRAYCELL) {
-                  error(7);        /* array sizes must match */
+                  error(47);        /* array sizes must match */
                 } else {
                   assert(lval.constval!=0); /* literal array must have a size */
                   /* A literal array must have exactly the same size as the

--- a/source/compiler/tests/warning_047.meta
+++ b/source/compiler/tests/warning_047.meta
@@ -1,0 +1,6 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+warning_047.pwn(8) : error 047: array sizes do not match, or destination array is too small
+"""
+}

--- a/source/compiler/tests/warning_047.pwn
+++ b/source/compiler/tests/warning_047.pwn
@@ -1,0 +1,17 @@
+Func2(const arr[3])
+{
+	return arr[0];
+}
+
+Func1(const arr[])
+{
+	Func2(arr[0]); // Must be "error 047: array sizes do not match, or destination array
+	               // is too small", not "error 007: operator cannot be redefined"
+	               // (a typo in the error code made by the original Pawn author).
+}
+
+main()
+{
+	static const arr[1];
+	Func1(arr);
+}


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

Fixes an incorrect error message that originates from a typo in the error code (`error(7)` instead of `error(47)`) made by the original Pawn author.
The bug can be reproduced by passing a cell from a passed-by-reference array to a function that is supposed to take a fixed-length array instead:
```Pawn
Func2(const arr[3])
{
    return arr[0];
}

Func1(const arr[])
{
    Func2(arr[0]); // error 007: operator cannot be redefined
}

main()
{
    static const arr[1];
    Func1(arr);
}
```
In this example the correct error message should be `error 047: array sizes do not match, or destination array is too small`, not `error 007: operator cannot be redefined`.

**Which issue(s) this PR fixes**:

<!--
Please ensure you have discussed your proposed changes before committing time to writing code!

GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged
-->

Fixes #

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->