### PR TITLE
Fix user-defined assignment operators not being called for compound assignments

### DIFF
--- a/source/compiler/sc3.c
+++ b/source/compiler/sc3.c
@@ -1053,7 +1053,8 @@ static int hier14(value *lval1)
   if (leftarray) {
     memcopy(val*sizeof(cell));
   } else {
-    check_userop(NULL,lval2.tag,lval3.tag,2,&lval3,&lval2.tag);
+    if (check_userop(NULL,(oper==NULL) ? lval2.tag : lval1->tag,lval3.tag,2,&lval3,&lval2.tag))
+      lval1->tag=lval2.tag; /* user-defined assignment operator can override the resulting tag */
     store(&lval3);      /* now, store the expression result */
   } /* if */
   if (!oper)

--- a/source/compiler/tests/gh_517.meta
+++ b/source/compiler/tests/gh_517.meta
@@ -1,0 +1,5 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+"""
+}

--- a/source/compiler/tests/gh_517.pwn
+++ b/source/compiler/tests/gh_517.pwn
@@ -1,0 +1,20 @@
+stock Tag:operator=(oper)
+	return Tag:oper;
+
+stock operator+(Tag:oper1, Tag:oper2)
+	return (_:oper1 + _:oper2);
+
+stock operator+(Tag:oper1, oper2)
+	return (_:oper1 - oper2);
+
+main()
+{
+	new Tag:a;
+	a = a + Tag:1;
+	a = a + 2;
+	a += Tag:3;
+	a += 4;
+	a = (a += Tag:5);
+	a = (a += 6);
+	#pragma unused a
+}

--- a/source/compiler/tests/gh_517_pcode.meta
+++ b/source/compiler/tests/gh_517_pcode.meta
@@ -1,0 +1,69 @@
+{
+  'test_type': 'pcode_check',
+  'code_pattern': r"""
+[0-9a-f]+  nop
+[0-9a-f]+  load.s.pri fffffffc
+[0-9a-f]+  const.alt 00000001
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.alt
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000004
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  stor.s.pri fffffffc
+[0-9a-f]+  load.s.pri fffffffc
+[0-9a-f]+  const.alt 00000002
+[0-9a-f]+  push.alt
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000004
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  stor.s.pri fffffffc
+[0-9a-f]+  load.s.pri fffffffc
+[0-9a-f]+  const.alt 00000003
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.alt
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000004
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  stor.s.pri fffffffc
+[0-9a-f]+  load.s.pri fffffffc
+[0-9a-f]+  const.alt 00000004
+[0-9a-f]+  push.alt
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000004
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  stor.s.pri fffffffc
+[0-9a-f]+  load.s.pri fffffffc
+[0-9a-f]+  const.alt 00000005
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.alt
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000004
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  stor.s.pri fffffffc
+[0-9a-f]+  stor.s.pri fffffffc
+[0-9a-f]+  load.s.pri fffffffc
+[0-9a-f]+  const.alt 00000006
+[0-9a-f]+  push.alt
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000008
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  push.pri
+[0-9a-f]+  push.c 00000004
+[0-9a-f]+  call [0-9a-f]+
+[0-9a-f]+  stor.s.pri fffffffc
+[0-9a-f]+  stor.s.pri fffffffc
+[0-9a-f]+  nop
+"""
+}

--- a/source/compiler/tests/gh_517_pcode.pwn
+++ b/source/compiler/tests/gh_517_pcode.pwn
@@ -1,0 +1,22 @@
+stock Tag:operator=(oper)
+	return Tag:oper;
+
+stock operator+(Tag:oper1, Tag:oper2)
+	return (_:oper1 + _:oper2);
+
+stock operator+(Tag:oper1, oper2)
+	return (_:oper1 - oper2);
+
+main()
+{
+	new Tag:a;
+	__emit nop; /* mark the start of checked P-code, to avoid any possible collisions */
+	a = a + Tag:1;
+	a = a + 2;
+	a += Tag:3;
+	a += 4;
+	a = (a += Tag:5);
+	a = (a += 6);
+	__emit nop; /* mark the end of checked P-code */
+	#pragma unused a
+}


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

Fixes the compiler not calling user-defined assignment operator for compound assignments, as described in #517.

**Which issue(s) this PR fixes**:

<!--
Please ensure you have discussed your proposed changes before committing time to writing code!

GitHub tip: using "Fixes #<issue number> will automatically close the issue upon being merged
-->

Fixes #517 

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
