### PR TITLE
Print an error if an operator is declared/defined as 'public'

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3623,7 +3623,7 @@ static void funcstub(int fnative)
   if (fnative) {
     sym->usage=(short)(uNATIVE | uRETVALUE | uDEFINE | (sym->usage & uPROTOTYPED));
     sym->x.lib=curlibrary;
-  } else if (fpublic) {
+  } else if (fpublic && opertok==0) {
     sym->usage|=uPUBLIC;
   } /* if */
   sym->usage|=uFORWARD;
@@ -3634,6 +3634,11 @@ static void funcstub(int fnative)
   sc_attachdocumentation(sym);  /* attach any documenation to the function */
   if (!operatoradjust(opertok,sym,symbolname,tag))
     sym->usage &= ~uDEFINE;
+  if (fpublic && opertok!=0) {
+    char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
+    funcdisplayname(symname,sym->name);
+    error(56,symname);  /* operators cannot be public */
+  } /* if */
 
   if (getstates(symbolname)!=0) {
     if (fnative || opertok!=0)
@@ -3722,7 +3727,6 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
   } else {
     tag= (firsttag>=0) ? firsttag : pc_addtag(NULL);
     tok=lex(&val,&str);
-    assert(!fpublic);
     if (tok==tNATIVE || (tok==tPUBLIC && stock))
       error(42);                /* invalid combination of class specifiers */
     if (tok==tOPERATOR) {
@@ -3752,7 +3756,7 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
   sym=fetchfunc(symbolname,tag);/* get a pointer to the function entry */
   if (sym==NULL || (sym->usage & uNATIVE)!=0)
     return TRUE;                /* it was recognized as a function declaration, but not as a valid one */
-  if (fpublic)
+  if (fpublic && opertok==0)
     sym->usage|=uPUBLIC;
   if (fstatic)
     sym->fnumber=filenum;
@@ -3760,11 +3764,16 @@ static int newfunc(char *firstname,int firsttag,int fpublic,int fstatic,int stoc
   /* we want public functions to be explicitly prototyped, as they are called
    * from the outside
    */
-  if (fpublic && (sym->usage & uFORWARD)==0)
+  if (fpublic && (sym->usage & uFORWARD)==0 && opertok==0)
     error(235,symbolname);
   /* declare all arguments */
   argcnt=declargs(sym,TRUE);
   opererror=!operatoradjust(opertok,sym,symbolname,tag);
+  if (fpublic && opertok!=0) {
+    char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
+    funcdisplayname(symname,sym->name);
+    error(56,symname);  /* operators cannot be public */
+  } /* if */
   if (strcmp(symbolname,uMAINFUNC)==0 || strcmp(symbolname,uENTRYFUNC)==0) {
     if (argcnt>0)
       error(5);         /* "main()" and "entry()" functions may not have any arguments */

--- a/source/compiler/sc5.c
+++ b/source/compiler/sc5.c
@@ -95,7 +95,7 @@ static char *errmsg[] = {
 /*053*/  "exceeding maximum number of dimensions\n",
 /*054*/  "unmatched closing brace (\"}\")\n",
 /*055*/  "start of function body without function header\n",
-/*056*/  "arrays, local variables and function arguments cannot be public (variable \"%s\")\n",
+/*056*/  "arrays, local variables, function arguments and user-defined operators cannot be public (symbol \"%s\")\n",
 /*057*/  "unfinished expression before compiler directive\n",
 /*058*/  "duplicate argument; same argument is passed twice\n",
 /*059*/  "function argument may not have a default value (variable \"%s\")\n",

--- a/source/compiler/tests/gh_522.meta
+++ b/source/compiler/tests/gh_522.meta
@@ -1,0 +1,10 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_522.pwn(3) : error 056: arrays, local variables, function arguments and user-defined operators cannot be public (symbol "_:operator=(Tag:)")
+gh_522.pwn(4) : error 056: arrays, local variables, function arguments and user-defined operators cannot be public (symbol "_:operator=(Tag:)")
+gh_522.pwn(5) : error 056: arrays, local variables, function arguments and user-defined operators cannot be public (symbol "_:operator=(Tag:)")
+gh_522.pwn(15) : warning 203: symbol is never used: "_:operator=(Tag:)"
+gh_522.pwn(15) : warning 203: symbol is never used: "_:operator=(Tag2:)"
+"""
+}

--- a/source/compiler/tests/gh_522.pwn
+++ b/source/compiler/tests/gh_522.pwn
@@ -1,0 +1,14 @@
+#pragma option -;+
+
+forward public operator=(Tag:a);
+public operator=(Tag:a);
+public operator=(Tag:a) return _:a;
+
+forward operator=(Tag2:a);
+operator=(Tag2:a);
+operator=(Tag2:a) return _:a;
+
+forward Func();
+public Func();
+forward public Func();
+public Func(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an oversight with the compiler not checking if the operator has been declared/defined with the `public` specifier, as described in #522.

Example of how it's handled in this PR:
```Pawn
forward public operator=(Tag:a);
public operator=(Tag:a) return _:a;
```
```
test.pwn(1) : error 056: arrays, local variables, function arguments and user-defined operators cannot be public (symbol "_:operator=(Tag:)")
test.pwn(2) : error 056: arrays, local variables, function arguments and user-defined operators cannot be public (symbol "_:operator=(Tag:)")
```
At first I couldn't find any fitting message for this kind of error, so I had a choice: either add a new error message (something like `"user-defined operators cannot be public (symbol \"%s\")"`) or modify an existing error message and reuse it.
Since we're almost out of free error IDs (currently only 6 left), I chose the second option and reused error 056 (`"arrays, local variables and function arguments cannot be public (variable \"%s\")"`) by adding a mention of user-defined operators into it and replacing "variable" with a more generic "symbol".
Please let me know if creating a new error message is more preferable in this case.

**Which issue(s) this PR fixes**:

Fixes #522

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
