### PR TITLE
Fix assertion failure when a native operator is declared without a base function

### DIFF
--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -3660,11 +3660,7 @@ static void funcstub(int fnative)
    * for a native function, this is optional
    */
   if (fnative) {
-    if (opertok!=0) {
-      needtoken('=');
-      lexpush();        /* push back, for matchtoken() to retrieve again */
-    } /* if */
-    if (matchtoken('=')) {
+    if ((opertok!=0) ? needtoken('=') : matchtoken('=')) {
       /* allow number or symbol */
       if (matchtoken(tSYMBOL)) {
         tokeninfo(&val,&str);

--- a/source/compiler/tests/gh_525.meta
+++ b/source/compiler/tests/gh_525.meta
@@ -1,0 +1,6 @@
+{
+  'test_type': 'output_check',
+  'errors': """
+gh_525.pwn(1) : error 001: expected token: "=", but found ";"
+  """
+}

--- a/source/compiler/tests/gh_525.pwn
+++ b/source/compiler/tests/gh_525.pwn
@@ -1,0 +1,8 @@
+native Tag:operator+(Tag:a, Tag:b); // error 001: expected token: "=", but found ";"
+
+// Make sure that valid native operator and function declarations aren't affected
+native Tag2:operator+(Tag2:a, Tag2:b) = NativeFunc;
+native Tag2:NativeFunc(Tag2:a, Tag2:b);
+native NativeFunc2(a,b) = NativeFunc;
+
+main(){}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes assertion failure when the user forgets to specify a function the native operator is based on, as described in #524.

**Which issue(s) this PR fixes**:

Fixes #524 

**What kind of pull this is**:

* [x] A Bug Fix
* [ ] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:
